### PR TITLE
use useEffect() for subscribe HOC generator

### DIFF
--- a/src/subscribeToStateUpdates.tsx
+++ b/src/subscribeToStateUpdates.tsx
@@ -3,7 +3,6 @@
 // May require use of typescript generics.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentType, useMemo, useReducer, ComponentState, useEffect } from 'react';
-import { Unsubscribe } from '@reduxjs/toolkit';
 import { State } from '@yext/answers-headless/lib/esm/models/state';
 import { useAnswersActions } from './useAnswersActions';
 


### PR DESCRIPTION
I recently learned that useEffect accepts a cleanup callback
as its return value. This is simpler than manually keeping track
of the cleanup.

TEST=manual

see sample-app still run