### PR TITLE
Add base SCSS fonts, colors, mixins, and layouts from the SDK.

### DIFF
--- a/sample-app/src/sass/App.scss
+++ b/sample-app/src/sass/App.scss
@@ -1,3 +1,9 @@
+// Variables and mixins
+@import "layout";
+@import "mixins";
+@import "fonts";
+@import "colors";
+
 .App {
   display: flex;
   align-items: center;

--- a/sample-app/src/sass/_colors.scss
+++ b/sample-app/src/sass/_colors.scss
@@ -1,0 +1,33 @@
+$color-background-highlight: #fafafa !default;
+$color-background-dark: #A8A8A8 !default;
+$color-brand-primary: #0f70f0 !default;
+$color-brand-hover: #0C5ECB !default;
+$color-brand-white: #fff !default;
+
+$color-text-primary: #212121 !default;
+$color-text-secondary: #757575 !default;
+$color-text-neutral: #616161 !default;
+
+$color-link-primary: var(--yxt-color-brand-primary) !default;
+
+$color-borders: #dcdcdc !default;
+
+$color-error: #940000 !default;
+
+:root {
+  --yxt-color-background-highlight: #{$color-background-highlight};
+  --yxt-color-background-dark: #{$color-background-dark};
+  --yxt-color-brand-primary: #{$color-brand-primary};
+  --yxt-color-brand-hover: #{$color-brand-hover};
+  --yxt-color-brand-white: #{$color-brand-white};
+
+  --yxt-color-text-primary: #{$color-text-primary};
+  --yxt-color-text-secondary: #{$color-text-secondary};
+  --yxt-color-text-neutral: #{$color-text-neutral};
+
+  --yxt-color-link-primary: #{$color-link-primary};
+
+  --yxt-color-borders: #{$color-borders};
+
+  --yxt-color-error: #{$color-error};
+}

--- a/sample-app/src/sass/_fonts.scss
+++ b/sample-app/src/sass/_fonts.scss
@@ -1,0 +1,48 @@
+@use "sass:math";
+
+$font-weight-bold: 700 !default;
+$font-weight-semibold: 600 !default;
+$font-weight-medium: 500 !default;
+$font-weight-normal: 400 !default;
+$font-weight-light: 300 !default;
+
+$font-size-xs: 10px !default;
+$font-size-sm: 12px !default;
+$font-size-md: 14px !default;
+$font-size-md-lg: 16px !default;
+$font-size-lg: 18px !default;
+$font-size-xlg: 20px !default;
+$font-size-xxlg: 40px !default;
+
+$line-height-xs: 1 !default;
+$line-height-sm: 1.2 !default;
+$line-height-md-sm: math.div(4, 3) !default;
+$line-height-md: 1.4 !default;
+$line-height-lg: 1.5 !default;
+$line-height-xlg: math.div(5, 3) !default;
+$line-height-xxlg: 1.7 !default;
+
+$font-family: system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif !default;
+
+:root {
+  --yxt-font-weight-bold: #{$font-weight-bold};
+  --yxt-font-weight-semibold: #{$font-weight-semibold};
+  --yxt-font-weight-medium: #{$font-weight-medium};
+  --yxt-font-weight-normal: #{$font-weight-normal};
+  --yxt-font-weight-light: #{$font-weight-light};
+  --yxt-font-size-xs: #{$font-size-xs};
+  --yxt-font-size-sm: #{$font-size-sm};
+  --yxt-font-size-md: #{$font-size-md};
+  --yxt-font-size-md-lg: #{$font-size-md-lg};
+  --yxt-font-size-lg: #{$font-size-lg};
+  --yxt-font-size-xlg: #{$font-size-xlg};
+  --yxt-font-size-xxlg: #{$font-size-xxlg};
+  --yxt-line-height-xs: #{$line-height-xs};
+  --yxt-line-height-sm: #{$line-height-sm};
+  --yxt-line-height-md-sm: #{$line-height-md-sm};
+  --yxt-line-height-md: #{$line-height-md};
+  --yxt-line-height-lg: #{$line-height-lg};
+  --yxt-line-height-xlg: #{$line-height-xlg};
+  --yxt-line-height-xxlg: #{$line-height-xxlg};
+  --yxt-font-family: #{$font-family};
+}

--- a/sample-app/src/sass/_layout.scss
+++ b/sample-app/src/sass/_layout.scss
@@ -1,0 +1,35 @@
+$base-spacing-sm: 12px !default;
+$base-spacing: 16px !default;
+
+$module-footer-height: 24px !default;
+$module-container-height: 20px !default;
+
+$border-default: 1px solid var(--yxt-color-borders)!default;
+$border-legacy: 1px solid #e9e9e9 !default;
+$yxt-border-hover: 1px solid var(--yxt-color-brand-hover) !default;
+
+$breakpoint-mobile-max: 767px !default;
+$breakpoint-mobile-min: 768px !default;
+
+$breakpoint-mobile-sm-max: 575px !default;
+$breakpoint-mobile-sm-min: 576px !default;
+$z-index-nav-more-modal: 2 !default;
+
+$button-focus-border-size: 3px !default;
+
+$cards-min-width: 210px !default;
+$container-desktop-base: 400px !default;
+
+:root {
+  --yxt-base-spacing-sm: #{$base-spacing-sm};
+  --yxt-base-spacing: #{$base-spacing};
+  --yxt-module-footer-height: #{$module-footer-height};
+  --yxt-module-container-height: #{$module-container-height};
+  --yxt-border-default: #{$border-default};
+  --yxt-border-hover: #{$yxt-border-hover};
+  --yxt-border-legacy: #{$border-legacy};
+  --yxt-z-index-nav-more-modal: #{$z-index-nav-more-modal};
+  --yxt-button-focus-border-size: #{$button-focus-border-size};
+  --yxt-cards-min-width: #{$cards-min-width};
+  --yxt-container-desktop-base: #{$container-desktop-base};
+}

--- a/sample-app/src/sass/_mixins.scss
+++ b/sample-app/src/sass/_mixins.scss
@@ -1,0 +1,102 @@
+@mixin Text(
+  $size: var(--yxt-font-size-md),
+  $line-height: var(--yxt-line-height-xs),
+  $weight: var(--yxt-font-weight-normal),
+  $style: normal,
+  $color: var(--yxt-color-text-primary)
+) {
+  font-family: var(--yxt-font-family);
+  font-size: $size;
+  line-height: $line-height;
+  font-weight: $weight;
+  font-style: $style;
+  color: $color;
+}
+
+@mixin TextButton(
+  $padding: 5px 10px,
+  $focus-color: var(--yxt-color-brand-hover)
+) {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: $padding;
+
+  &:not(:disabled) {
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus {
+      color: $focus-color;
+      border: 1px solid $focus-color;
+    }
+  }
+}
+
+@mixin Button(
+
+) {
+  border: 0;
+  border-radius: 3px;
+  margin-top: 16px;
+  background: var(--yxt-color-brand-primary);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+
+  &:not(:disabled){
+    cursor: pointer;
+
+    &:hover, &:focus {
+      background: padding-box var(--yxt-color-brand-hover);
+    }
+
+    &:focus {
+      border: var(--yxt-button-focus-border-size) double #0c5ecb;
+    }
+  }
+}
+
+@mixin Link(
+  $base-color: inherit,
+  $base-decoration: none,
+  $hover-color: $base-color,
+  $hover-decoration: underline,
+  $active-color: $hover-color
+) {
+    &:link,
+    &:visited
+   {
+       color: $base-color;
+       text-decoration: $base-decoration;
+   }
+
+    &:hover,
+    &:focus
+    {
+      color: $hover-color;
+      text-decoration: $hover-decoration;
+    }
+
+    &:active
+    {
+        color: $active-color;
+        text-decoration: $hover-decoration;
+    }
+}
+
+@mixin Link-1
+{
+  @include Link($base-color: var(--yxt-color-brand-primary));
+}
+
+@mixin Link-2
+{
+  @include Link(
+    $base-color: var(--yxt-color-brand-primary),
+    $base-decoration: underline,
+    $hover-decoration: none
+  );
+}


### PR DESCRIPTION
This will help in the styling of the SDK components we're cutting over. We may change some of this styling
ultimately or get rid of some of it. The React app does not need the same degree of bespoke styling as the SDK.