### PR TITLE
update Autocomplete component's results on 'Show' instead of on 'Hide'

### DIFF
--- a/sample-app/src/components/Autocomplete.tsx
+++ b/sample-app/src/components/Autocomplete.tsx
@@ -23,7 +23,6 @@ interface State {
 }
 
 type Action = 
-  | { type: 'Show' }
   | { type: 'Hide' }
   | { type: 'InputClick' }
   | { type: 'InputChange' }
@@ -32,10 +31,13 @@ type Action =
 
 function reducer(state: State, action: Action): State {
   switch(action.type) {
-    case 'Show': 
-      return { ...state, shouldDisplay: true }
     case 'Hide': 
-      return { ...state, selectedIndex: -1, shouldDisplay: false }
+      return {
+        ...state,
+        selectedIndex: -1,
+        shouldDisplay: false,
+        autocompleteResults: []
+      }
     case 'InputChange': 
       return { ...state, selectedIndex: -1, shouldDisplay: true }
     case 'InputClick': 
@@ -43,6 +45,7 @@ function reducer(state: State, action: Action): State {
     case 'UpdateAutocomplete': 
       return {
         ...state,
+        shouldDisplay: true,
         autocompleteResults: action.results,
         lastAutocompleteQuery: action.lastAutocompleteQuery
       }
@@ -83,9 +86,8 @@ export default function Autocomplete({
     const target = evt.target as HTMLElement;
     if (!target || !target.isSameNode(inputRef.current)) {
       dispatch({ type: 'Hide' });
-      updateAutocompleteResults(query);
     } else {
-      dispatch({ type: 'Show' });
+      updateAutocompleteResults(query);
     }
   }
   useEffect(() => {


### PR DESCRIPTION
Previously, I updated the Autocomplete component's results on the
'Hide' action as opposed to the 'Show' action, as a slight optimization.
However, the 'Hide' action would occur when the user clicks outside of the
Autocomplete, which would cause multiple Autocomplete components to clobber
each other when setting the global query state.

Instead, it probably makes more sense to run the autocomplete request when
the 'Show' action is run. This results in very slight lag for the component,
but I think is a more intuitive flow. We can always optimize later.
This is also the behavior the SDK does right now.

In greater detail, the flow was:
1. user types in "prompt" and gets an autocomplete result "prompt for"
2. users presses the down arrow key to highlight "prompt for"
3. user clicks OUT of the autocomplete by clicking on the document.
4. (old behavior) previously, an autocomplete request for "prompt for" would immediately be run and stored in the component, and the autocomplete would hide itself
4.  (new behavior) autocomplete just hides itself and clears its autocompleteResults state
5. user clicks into the autocomplete component again
6.  (old) the autocomplete would display itself, and use the already stored results for "prompt for"
6.  (new) the autocomplete makes a new request for "prompt for", and displays those results

TEST=manual

test that there is no flickering of autocomplete results when clicking in and out of it
see that no request is made when clicking on the document, meaning we're not tampering with
the global query on document click