### PR TITLE
Respect isVertical setting in SearchBar

### DIFF
--- a/sample-app/src/components/SearchBar.tsx
+++ b/sample-app/src/components/SearchBar.tsx
@@ -28,13 +28,17 @@ export default function SearchBar({ placeholder, isVertical }: Props) {
       : answersActions.executeUniversalAutoComplete()
   }
 
+  function executeQuery () {
+    isVertical 
+      ? answersActions.executeVerticalQuery()
+      : answersActions.executeUniversalQuery();
+  }
+
   function renderSearchButton () {
     return (
       <button
         className='SearchBar__submitButton'
-        onClick={() => {
-          answersActions.executeVerticalQuery();
-        }}
+        onClick={executeQuery}
       >
         <MagnifyingGlassIcon/>
       </button>
@@ -52,9 +56,7 @@ export default function SearchBar({ placeholder, isVertical }: Props) {
             render: () => renderWithHighlighting(result)
           }
         })}
-        onSubmit={() => {
-          answersActions.executeVerticalQuery();
-        }}
+        onSubmit={executeQuery}
         updateInputValue={value => {
           answersActions.setQuery(value);
         }}


### PR DESCRIPTION
The SearchBar has an isVertical prop which it uses to fetch
the correct autocomplete results, however it did not use the
prop when submitting a search.

J=None

TEST=manual
Using the updated searchbar component in a demo