### PR TITLE
Add default search loading state

### DIFF
--- a/sample-app/src/components/LoadingIndicator.tsx
+++ b/sample-app/src/components/LoadingIndicator.tsx
@@ -1,11 +1,11 @@
 import '../sass/LoadingIndicator.scss';
 
 export default function LoadingIndicator() {
-	return (
-		<div className="LoadingIndicator">
-      <svg className= "LoadingIndicator-AnimatedIcon" viewBox="0 0 72 72" height="24" width="24">
-        <circle className="LoadingIndicator-Circle" cx="36" cy="36" r="33" stroke="black" strokeWidth="3" fill="none"/>
+  return (
+    <div className="LoadingIndicator">
+      <svg className="LoadingIndicator__animatedIcon" viewBox="0 0 72 72" height="24" width="24">
+        <circle className="LoadingIndicator__circle" cx="36" cy="36" r="33" stroke="black" strokeWidth="3" fill="none"/>
       </svg>
     </div>
-	)
+  )
 }

--- a/sample-app/src/components/SearchBar.tsx
+++ b/sample-app/src/components/SearchBar.tsx
@@ -22,10 +22,7 @@ export default function SearchBar({ placeholder, isVertical }: Props) {
     ? state => state.vertical.autoComplete?.results
     : state => state.universal.autoComplete?.results;
   const autocompleteResults = useAnswersState(mapStateToAutocompleteResults) || [];
-  const loadingStateSelector: StateSelector<boolean | undefined> = isVertical
-    ? (state => state.vertical.searchLoading)
-    : (state => state.universal.searchLoading);
-  const isLoading = useAnswersState(loadingStateSelector);
+  const isLoading = useAnswersState(state => state.vertical.searchLoading || state.universal.searchLoading);
 
   function executeAutocomplete () {
     isVertical 

--- a/sample-app/src/components/VerticalResults.tsx
+++ b/sample-app/src/components/VerticalResults.tsx
@@ -23,7 +23,7 @@ export default function VerticalResults(props: Props): JSX.Element | null {
   const allResultsForVertical = useAnswersState(state => state.vertical.results?.allResultsForVertical?.verticalResults.results) || [];
 
   const isLoading = useAnswersState(state => state.vertical.searchLoading)
-  
+
   const results = verticalResults.length === 0 && displayAllResults
     ? allResultsForVertical
     : verticalResults
@@ -32,14 +32,13 @@ export default function VerticalResults(props: Props): JSX.Element | null {
     return null;
   }
 
-  const cs = classNames({
-		"yxt-Results-items": true,
-		"is-loading": isLoading,
-	})
+  const resultsClasses = classNames("VerticalResults__results", {
+    "VerticalResults__results--loading": isLoading,
+  })
 
   return (
-    <section className='yxt-Results'>
-      <div className={cs}>
+    <section className='VerticalResults'>
+      <div className={resultsClasses}>
         {results && results.map(result => renderResult(CardComponent, cardConfig, result))}
       </div>
     </section>

--- a/sample-app/src/sass/LoadingIndicator.scss
+++ b/sample-app/src/sass/LoadingIndicator.scss
@@ -11,7 +11,7 @@
     }
   }
 
-  &-AnimatedIcon 
+  &__animatedIcon 
   {
     stroke-dasharray: 208;
     transform-origin: 50% 50%;

--- a/sample-app/src/sass/VerticalResults.scss
+++ b/sample-app/src/sass/VerticalResults.scss
@@ -1,5 +1,7 @@
-.yxt-Results {
-  &-items.is-loading {
-    opacity: 0.5;
+.VerticalResults {
+  &__results {
+    &--loading {
+      opacity: 0.5;
+    }
   }
 }


### PR DESCRIPTION
Add 50% opacity on vertical results and the loading indicator from the SDK to the search bar when results are loading.

J=SLAP-1604
TEST=manual

Ran searches in the sample-app and saw vertical results opacity and the loading indicator in the search bar when loading results.