### PR TITLE
Add commonjs build

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -95,7 +95,7 @@ MIT License
 The following NPM packages may be included in this product:
 
  - @yext/answers-core@1.3.2
- - @yext/answers-headless-react@0.4.0-beta.0
+ - @yext/answers-headless-react@0.4.0-beta.1
  - @yext/answers-headless@0.1.0-beta.0
 
 These packages each contain the following license and notice below:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.2",
         "@types/react": "^17.0.15",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
       "@yext/answers-headless-react": "<rootDir>/src",
       "\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
       "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.ts"
+    },
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "tsconfig.esm.json"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "types": "./lib/index.d.ts",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "@yext/answers-headless-react",
   "version": "0.4.0-beta.0",
   "types": "./lib/index.d.ts",
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/esm/index.js",
   "files": [
     "lib"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "start": "cd sample-app && npm start",
-    "watch": "tsc --watch",
+    "watch": "tsc -p tsconfig.esm.json --watch",
     "install-sample-app": "cd sample-app && npm install",
     "test": "eslint . && jest",
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yext/answers-headless-react",
   "version": "0.4.0-beta.1",
-  "types": "./lib/index.d.ts",
+  "types": "./lib/esm/index.d.ts",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [

--- a/sample-app/package-lock.json
+++ b/sample-app/package-lock.json
@@ -89,7 +89,7 @@
     },
     "..": {
       "name": "@yext/answers-headless-react",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.2",
         "@types/react": "^17.0.15",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,11 +4,8 @@
     "paths": {
       "@yext/answers-headless-react": ["src"]
     },
-    "target": "es2015",
-    "outDir": "lib",
-    "esModuleInterop": true,
     "strict": true,
-    "module": "esnext",
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "noImplicitAny": false,
     "moduleResolution": "node",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "outDir": "lib/commonjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "outDir": "lib/esm"
+  }
+}


### PR DESCRIPTION
Add a commonjs build so that the library is compatible with node

There is a warning about useLayoutEffect since that is not compatible with server-side-rendering, however it still works. It will lead to a mismatch between the initial non-hydrated UI and the intended UI. If we do want to fully support that use case, there is more info here: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85, however that is out of scope of this item

J=SLAP-1666
TEST=manual

Use create-next-app and add answers-headless-react to it and test that a simple universal search works.  