### PR TITLE
Add labels to applied static filters

### DIFF
--- a/sample-app/src/components/DecoratedAppliedFilters.tsx
+++ b/sample-app/src/components/DecoratedAppliedFilters.tsx
@@ -3,14 +3,16 @@ import { AppliedQueryFilter } from "@yext/answers-core";
 import { useAnswersState } from '@yext/answers-headless-react';
 import { GroupedFilters } from '../models/groupedFilters';
 import { getGroupedAppliedFilters } from '../utils/appliedfilterutils';
-import { StaticFiltersLabelConfig } from "./StaticFilters";
 
 export interface DecoratedAppliedFiltersConfig {
   showFieldNames?: boolean,
   hiddenFields?: Array<string>,
   labelText?: string,
   delimiter?: string,
-  staticFiltersGroupLabels?: Record<string, StaticFiltersLabelConfig>,
+  /**
+   * A mapping of static filter fieldIds to their displayed group labels.
+   */
+  staticFiltersGroupLabels?: Record<string, string>,
   appliedQueryFilters?: AppliedQueryFilter[]
 }
 

--- a/sample-app/src/components/DecoratedAppliedFilters.tsx
+++ b/sample-app/src/components/DecoratedAppliedFilters.tsx
@@ -3,12 +3,14 @@ import { AppliedQueryFilter } from "@yext/answers-core";
 import { useAnswersState } from '@yext/answers-headless-react';
 import { GroupedFilters } from '../models/groupedFilters';
 import { getGroupedAppliedFilters } from '../utils/appliedfilterutils';
+import { StaticFiltersLabelConfig } from "./StaticFilters";
 
 export interface DecoratedAppliedFiltersConfig {
   showFieldNames?: boolean,
   hiddenFields?: Array<string>,
   labelText?: string,
   delimiter?: string,
+  staticFiltersGroupLabels?: Record<string, StaticFiltersLabelConfig>,
   appliedQueryFilters?: AppliedQueryFilter[]
 }
 
@@ -16,10 +18,10 @@ export interface DecoratedAppliedFiltersConfig {
  * Container component for AppliedFilters
  */
 export function DecoratedAppliedFiltersDisplay(props : DecoratedAppliedFiltersConfig): JSX.Element {
-  const { hiddenFields = [], appliedQueryFilters = [], ...otherProps } = props;
+  const { hiddenFields = [], staticFiltersGroupLabels = {}, appliedQueryFilters = [], ...otherProps } = props;
   const state = useAnswersState(state => state);
   const filterState = state.vertical.results ? state.filters : {};
-  const groupedFilters: Array<GroupedFilters> = getGroupedAppliedFilters(filterState, appliedQueryFilters, hiddenFields);
+  const groupedFilters: Array<GroupedFilters> = getGroupedAppliedFilters(filterState, appliedQueryFilters, hiddenFields, staticFiltersGroupLabels);
   return <AppliedFilters appliedFilters={groupedFilters} {...otherProps}/>
 }
 

--- a/sample-app/src/components/StaticFilters.tsx
+++ b/sample-app/src/components/StaticFilters.tsx
@@ -2,10 +2,6 @@ import React, { Fragment } from 'react';
 import { Filter, CombinedFilter, FilterCombinator, Matcher } from '@yext/answers-core';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-export interface StaticFiltersLabelConfig {
-  label: string
-}
-
 interface CheckBoxProps {
   fieldId: string,
   value: string,

--- a/sample-app/src/components/StaticFilters.tsx
+++ b/sample-app/src/components/StaticFilters.tsx
@@ -2,6 +2,10 @@ import React, { Fragment } from 'react';
 import { Filter, CombinedFilter, FilterCombinator, Matcher } from '@yext/answers-core';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
+export interface StaticFiltersLabelConfig {
+  label: string
+}
+
 interface CheckBoxProps {
   fieldId: string,
   value: string,

--- a/sample-app/src/pages/VerticalSearchPage.tsx
+++ b/sample-app/src/pages/VerticalSearchPage.tsx
@@ -51,9 +51,7 @@ const facetConfigs = {
 }
 
 const staticFiltersGroupLabels = {
-  c_employeeCountry: {
-    label: 'Employee Country'
-  }
+  c_employeeCountry: 'Employee Country'
 }
 
 export default function VerticalSearchPage(props: {

--- a/sample-app/src/pages/VerticalSearchPage.tsx
+++ b/sample-app/src/pages/VerticalSearchPage.tsx
@@ -50,6 +50,12 @@ const facetConfigs = {
   }
 }
 
+const staticFiltersGroupLabels = {
+  c_employeeCountry: {
+    label: 'Employee Country'
+  }
+}
+
 export default function VerticalSearchPage(props: {
   verticalKey: string
 }) {
@@ -87,6 +93,7 @@ export default function VerticalSearchPage(props: {
           showFieldNames={true}
           hiddenFields={['builtin.entityType']}
           delimiter='|'
+          staticFiltersGroupLabels={staticFiltersGroupLabels}
         />
         <AlternativeVerticals
           currentVerticalLabel='People'

--- a/sample-app/src/utils/appliedfilterutils.tsx
+++ b/sample-app/src/utils/appliedfilterutils.tsx
@@ -9,6 +9,7 @@ import {
   getDisplayableAppliedFacets,
   getDisplayableNlpFilters
 } from "./displayablefilterutils";
+import { StaticFiltersLabelConfig } from "../components/StaticFilters";
 
 /**
  * Returns a new list of nlp filters with duplicates of other filters and 
@@ -63,9 +64,10 @@ function createGroupedFilters(
 export function getGroupedAppliedFilters(
   appliedFiltersState: FiltersState,
   nlpFilters: AppliedQueryFilter[],
-  hiddenFields: string[]
+  hiddenFields: string[],
+  staticFiltersGroupLabels: Record<string, StaticFiltersLabelConfig>
 ): Array<GroupedFilters>  {
-  const displayableStaticFilters = getDisplayableStaticFilters(flattenFilters(appliedFiltersState?.static));
+  const displayableStaticFilters = getDisplayableStaticFilters(flattenFilters(appliedFiltersState?.static), staticFiltersGroupLabels);
   const displayableFacets = getDisplayableAppliedFacets(appliedFiltersState?.facets);
   const displayableNlpFilters = getDisplayableNlpFilters(nlpFilters);
   

--- a/sample-app/src/utils/appliedfilterutils.tsx
+++ b/sample-app/src/utils/appliedfilterutils.tsx
@@ -9,7 +9,6 @@ import {
   getDisplayableAppliedFacets,
   getDisplayableNlpFilters
 } from "./displayablefilterutils";
-import { StaticFiltersLabelConfig } from "../components/StaticFilters";
 
 /**
  * Returns a new list of nlp filters with duplicates of other filters and 
@@ -65,7 +64,7 @@ export function getGroupedAppliedFilters(
   appliedFiltersState: FiltersState,
   nlpFilters: AppliedQueryFilter[],
   hiddenFields: string[],
-  staticFiltersGroupLabels: Record<string, StaticFiltersLabelConfig>
+  staticFiltersGroupLabels: Record<string, string>
 ): Array<GroupedFilters>  {
   const displayableStaticFilters = getDisplayableStaticFilters(flattenFilters(appliedFiltersState?.static), staticFiltersGroupLabels);
   const displayableFacets = getDisplayableAppliedFacets(appliedFiltersState?.facets);

--- a/sample-app/src/utils/displayablefilterutils.tsx
+++ b/sample-app/src/utils/displayablefilterutils.tsx
@@ -1,5 +1,4 @@
 import { AppliedQueryFilter, Filter, DisplayableFacet } from '@yext/answers-core';
-import { StaticFiltersLabelConfig } from '../components/StaticFilters';
 import { DisplayableFilter } from '../models/displayableFilter';
 import { getFilterDisplayValue } from './filterutils';
 
@@ -32,14 +31,14 @@ export function getDisplayableAppliedFacets(facets: DisplayableFacet[] | undefin
  */
 export function getDisplayableStaticFilters(
   filters: Filter[],
-  groupLabels: Record<string, StaticFiltersLabelConfig>
+  groupLabels: Record<string, string>
 ): DisplayableFilter[] {
   let appliedStaticFilters: DisplayableFilter[] = [];
   filters?.forEach(filter => {
     appliedStaticFilters.push({
       filterType: 'STATIC_FILTER',
       filter: filter,
-      groupLabel: groupLabels?.[filter.fieldId]?.label || filter.fieldId,
+      groupLabel: groupLabels?.[filter.fieldId] || filter.fieldId,
       label: getFilterDisplayValue(filter),
     });
   });

--- a/sample-app/src/utils/displayablefilterutils.tsx
+++ b/sample-app/src/utils/displayablefilterutils.tsx
@@ -1,4 +1,5 @@
 import { AppliedQueryFilter, Filter, DisplayableFacet } from '@yext/answers-core';
+import { StaticFiltersLabelConfig } from '../components/StaticFilters';
 import { DisplayableFilter } from '../models/displayableFilter';
 import { getFilterDisplayValue } from './filterutils';
 
@@ -29,13 +30,16 @@ export function getDisplayableAppliedFacets(facets: DisplayableFacet[] | undefin
 /**
  * Convert a list of static filters to DisplayableFilter format.
  */
-export function getDisplayableStaticFilters(filters: Filter[]): DisplayableFilter[] {
+export function getDisplayableStaticFilters(
+  filters: Filter[],
+  groupLabels: Record<string, StaticFiltersLabelConfig>
+): DisplayableFilter[] {
   let appliedStaticFilters: DisplayableFilter[] = [];
   filters?.forEach(filter => {
     appliedStaticFilters.push({
       filterType: 'STATIC_FILTER',
       filter: filter,
-      groupLabel: filter.fieldId,
+      groupLabel: groupLabels?.[filter.fieldId]?.label || filter.fieldId,
       label: getFilterDisplayValue(filter),
     });
   });


### PR DESCRIPTION
Allow users to specify group labels for applied static filters. `DecoratedAppliedFilters` accepts a mapping of `fieldId` to group label. If no label is provided, it defaults back to using the `fieldId` as the group label.

J=SLAP-1658
TEST=manual

Check that specifying a group label for a static filter fieldId is reflected when a filter with that fieldId is applied