### PR TITLE
export * answers-headless

### DIFF
--- a/sample-app/package-lock.json
+++ b/sample-app/package-lock.json
@@ -23,7 +23,6 @@
         "@types/react-router-dom": "^5.3.0",
         "@typescript-eslint/eslint-plugin": "^4.5.0",
         "@typescript-eslint/parser": "^4.5.0",
-        "@yext/answers-core": "^1.2.0",
         "@yext/answers-headless-react": "file:..",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.6.0",
@@ -4124,18 +4123,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
-    "node_modules/@yext/answers-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.2.0.tgz",
-      "integrity": "sha512-s2jg5OwhwOMY7sh/dlkF2aIOxOSOKhIzny8O+Jn0/yjxBpHcZ++RvZDCt3xcYGSwKVQIyQ6RTo2K2e9f6yj1iA==",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/@yext/answers-headless-react": {
       "resolved": "..",
       "link": true
@@ -6508,14 +6495,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-      "dependencies": {
-        "node-fetch": "2.6.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -14073,14 +14052,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
     },
     "node_modules/node-forge": {
       "version": "0.10.0",
@@ -25105,15 +25076,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
-    "@yext/answers-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.2.0.tgz",
-      "integrity": "sha512-s2jg5OwhwOMY7sh/dlkF2aIOxOSOKhIzny8O+Jn0/yjxBpHcZ++RvZDCt3xcYGSwKVQIyQ6RTo2K2e9f6yj1iA==",
-      "requires": {
-        "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.0.6"
-      }
-    },
     "@yext/answers-headless-react": {
       "version": "file:..",
       "requires": {
@@ -27059,14 +27021,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-      "requires": {
-        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -32925,11 +32879,6 @@
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",

--- a/sample-app/package.json
+++ b/sample-app/package.json
@@ -17,7 +17,6 @@
     "@types/react-router-dom": "^5.3.0",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
-    "@yext/answers-core": "^1.2.0",
     "@yext/answers-headless-react": "file:..",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.0",

--- a/sample-app/src/components/AlternativeVerticals.tsx
+++ b/sample-app/src/components/AlternativeVerticals.tsx
@@ -1,8 +1,7 @@
 import { processTranslation } from './utils/processTranslation';
 import { ReactComponent as Chevron } from '../icons/chevron.svg';
 import { ReactComponent as Star } from '../icons/star.svg';
-import { useAnswersState, useAnswersActions } from '@yext/answers-headless-react';
-import { VerticalResults } from '@yext/answers-core';
+import { useAnswersState, useAnswersActions, VerticalResults } from '@yext/answers-headless-react';
 import '../sass/AlternativeVerticals.scss';
 
 interface VerticalConfig {

--- a/sample-app/src/components/DecoratedAppliedFilters.tsx
+++ b/sample-app/src/components/DecoratedAppliedFilters.tsx
@@ -1,6 +1,5 @@
 import AppliedFilters from "./AppliedFilters";
-import { AppliedQueryFilter } from "@yext/answers-core";
-import { useAnswersState } from '@yext/answers-headless-react';
+import { useAnswersState, AppliedQueryFilter } from '@yext/answers-headless-react';
 import { GroupedFilters } from '../models/groupedFilters';
 import { getGroupedAppliedFilters } from '../utils/appliedfilterutils';
 

--- a/sample-app/src/components/Facet.tsx
+++ b/sample-app/src/components/Facet.tsx
@@ -1,5 +1,4 @@
-import { useAnswersUtilities } from '@yext/answers-headless-react'
-import { DisplayableFacet, DisplayableFacetOption } from '@yext/answers-core';
+import { useAnswersUtilities, DisplayableFacet, DisplayableFacetOption } from '@yext/answers-headless-react'
 import { useState } from 'react';
 import useCollapse from 'react-collapsed';
 import '../sass/Facet.scss';

--- a/sample-app/src/components/Facets.tsx
+++ b/sample-app/src/components/Facets.tsx
@@ -1,5 +1,4 @@
-import { useAnswersState, useAnswersActions } from '@yext/answers-headless-react'
-import { DisplayableFacetOption } from "@yext/answers-core";
+import { useAnswersState, useAnswersActions, DisplayableFacetOption } from '@yext/answers-headless-react'
 import Facet, { FacetTextConfig } from './Facet';
 import '../sass/Facets.scss';
 

--- a/sample-app/src/components/LocationBias.tsx
+++ b/sample-app/src/components/LocationBias.tsx
@@ -1,6 +1,4 @@
-
-import { LocationBiasMethod } from '@yext/answers-core';
-import { useAnswersActions, useAnswersState } from '@yext/answers-headless-react';
+import { useAnswersActions, useAnswersState, LocationBiasMethod } from '@yext/answers-headless-react';
 
 interface Props {
   isVertical: boolean,

--- a/sample-app/src/components/SearchBar.tsx
+++ b/sample-app/src/components/SearchBar.tsx
@@ -1,5 +1,4 @@
-import { useAnswersActions, useAnswersState, StateSelector } from '@yext/answers-headless-react';
-import { AutocompleteResult } from '@yext/answers-core';
+import { useAnswersActions, useAnswersState, StateSelector, AutocompleteResult } from '@yext/answers-headless-react';
 import InputDropdown from './InputDropdown';
 import renderWithHighlighting from './utils/renderWithHighlighting';
 import { ReactComponent as MagnifyingGlassIcon } from '../icons/magnifying_glass.svg';

--- a/sample-app/src/components/StaticFilters.tsx
+++ b/sample-app/src/components/StaticFilters.tsx
@@ -1,6 +1,4 @@
-import { Fragment } from 'react';
-import { Filter, Matcher } from '@yext/answers-core';
-import { useAnswersActions, useAnswersState } from '@yext/answers-headless-react';
+import { useAnswersActions, useAnswersState, Filter, Matcher } from '@yext/answers-headless-react';
 import { isDuplicateFilter } from '../utils/filterutils';
 
 interface CheckBoxProps {
@@ -31,7 +29,7 @@ function CheckboxFilter({ fieldId, value, label, selected, optionHandler }: Chec
   }
   const id = fieldId + "_" + value
   return (
-    <Fragment>
+    <>
       <label htmlFor={id}>{label}</label>
       <input 
         type="checkbox"
@@ -39,7 +37,7 @@ function CheckboxFilter({ fieldId, value, label, selected, optionHandler }: Chec
         checked={selected}
         onChange={evt => optionHandler(filter, evt.target.checked)}
       />
-    </Fragment>
+    </>
   );
 }
 

--- a/sample-app/src/components/UniversalResults.tsx
+++ b/sample-app/src/components/UniversalResults.tsx
@@ -1,5 +1,4 @@
-import { useAnswersState } from "@yext/answers-headless-react";
-import { VerticalResults } from "@yext/answers-core";
+import { useAnswersState, VerticalResults } from "@yext/answers-headless-react";
 import StandardSection from "../sections/StandardSection";
 import { DecoratedAppliedFiltersConfig } from '../components/DecoratedAppliedFilters';
 import SectionHeader from "../sections/SectionHeader";

--- a/sample-app/src/components/VerticalResults.tsx
+++ b/sample-app/src/components/VerticalResults.tsx
@@ -1,6 +1,5 @@
 import { CardComponent, CardConfigTypes } from '../models/cardComponent';
-import { Result } from '@yext/answers-core';
-import { useAnswersState } from '@yext/answers-headless-react';
+import { useAnswersState, Result } from '@yext/answers-headless-react';
 import classNames from 'classnames';
 import '../sass/VerticalResults.scss';
 

--- a/sample-app/src/models/cardComponent.ts
+++ b/sample-app/src/models/cardComponent.ts
@@ -1,4 +1,4 @@
-import { Result } from '@yext/answers-core';
+import { Result } from '@yext/answers-headless-react';
 import { StandardCardConfig } from '../components/cards/StandardCard';
 
 /**

--- a/sample-app/src/models/displayableFilter.ts
+++ b/sample-app/src/models/displayableFilter.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@yext/answers-core';
+import { Filter } from '@yext/answers-headless-react';
 
 export interface DisplayableFilter {
   filterType: 'NLP_FILTER' | 'STATIC_FILTER' | 'FACET',

--- a/sample-app/src/models/sectionComponent.ts
+++ b/sample-app/src/models/sectionComponent.ts
@@ -1,4 +1,4 @@
-import { Result } from "@yext/answers-core";
+import { Result } from "@yext/answers-headless-react";
 import { CardConfig } from './cardComponent';
 
 export interface SectionConfig {

--- a/sample-app/src/utils/appliedfilterutils.tsx
+++ b/sample-app/src/utils/appliedfilterutils.tsx
@@ -1,4 +1,4 @@
-import { AppliedQueryFilter } from "@yext/answers-core";
+import { AppliedQueryFilter } from "@yext/answers-headless-react";
 import { FiltersState } from "@yext/answers-headless/lib/esm/models/slices/filters";
 import { DisplayableFilter } from "../models/displayableFilter";
 import { GroupedFilters } from "../models/groupedFilters";

--- a/sample-app/src/utils/displayablefilterutils.tsx
+++ b/sample-app/src/utils/displayablefilterutils.tsx
@@ -1,4 +1,4 @@
-import { AppliedQueryFilter, DisplayableFacet } from '@yext/answers-core';
+import { AppliedQueryFilter, DisplayableFacet } from '@yext/answers-headless-react';
 import { SelectableFilter } from '@yext/answers-headless/lib/esm/models/utils/selectablefilter';
 import { DisplayableFilter } from '../models/displayableFilter';
 import { getFilterDisplayValue } from './filterutils';

--- a/sample-app/src/utils/filterutils.tsx
+++ b/sample-app/src/utils/filterutils.tsx
@@ -1,4 +1,4 @@
-import { NearFilterValue, CombinedFilter, Filter } from '@yext/answers-core';
+import { NearFilterValue, CombinedFilter, Filter } from '@yext/answers-headless-react';
 
 /**
  * Check if the object follows NearFilterValue interface

--- a/src/AnswersHeadlessProvider.tsx
+++ b/src/AnswersHeadlessProvider.tsx
@@ -1,6 +1,5 @@
 import { ReactChild, ReactChildren } from 'react';
-import { provideAnswersHeadless, AnswersHeadless } from '@yext/answers-headless';
-import { AnswersConfig } from '@yext/answers-core';
+import { provideAnswersHeadless, AnswersHeadless, AnswersConfig } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 
 interface Props extends AnswersConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { subscribeToStateUpdates } from './subscribeToStateUpdates';
 import { AnswersHeadlessProvider } from './AnswersHeadlessProvider';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 
+export * from '@yext/answers-headless';
 export {
   AnswersHeadlessContext,
   subscribeToStateUpdates,

--- a/tests/components/appliedFilters.test.tsx
+++ b/tests/components/appliedFilters.test.tsx
@@ -1,8 +1,7 @@
 import { act, render } from '@testing-library/react';
-import { provideAnswersHeadless } from '@yext/answers-headless';
+import { provideAnswersHeadless, Matcher } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from '../../src';
 import DecoratedAppliedFilters from '../../sample-app/src/components/DecoratedAppliedFilters';
-import { Matcher } from '@yext/answers-core';
 import { useCallback } from 'react';
 import { verticalQueryResponseWithNlpFilters } from '../setup/responses/vertical-query';
 

--- a/tests/useAnswersState.test.tsx
+++ b/tests/useAnswersState.test.tsx
@@ -1,7 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Result } from '@yext/answers-core';
-import { provideAnswersHeadless } from '@yext/answers-headless';
+import { provideAnswersHeadless, Result } from '@yext/answers-headless';
 import { State } from '@yext/answers-headless/lib/esm/models/state';
 import React, { useCallback, useReducer } from 'react';
 import { AnswersHeadlessContext, useAnswersActions, useAnswersState } from '../src';


### PR DESCRIPTION
This commit adds an export * from answers-headless statement.
This way, the sample-app doesn't have to use a transient answers-core
or answers-headless dependency for models.
This also makes local development slightly nicer, since transitive dependencies aren't visible
when doing a local npm install.

J=SLAP-1684
TEST=manual

see the sample app runs