### PR TITLE
Use case: Guided Search

### DIFF
--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -5,15 +5,22 @@ import PageRouter from './PageRouter';
 import StandardLayout from './pages/StandardLayout';
 import { AnswersHeadlessProvider } from '@yext/answers-headless-react';
 import { universalResultsConfig } from './universalResultsConfig';
+import GuidedSearchPage from './pages/GuidedSearchPage';
 
 const routes = [
   {
+    Layout: StandardLayout,
     path: '/',
     exact: true,
     page: <UniversalSearchPage universalResultsConfig={universalResultsConfig} />
   },
+  {
+    path: '/prompt',
+    page: <GuidedSearchPage verticalKey='people' />
+  },
   ...Object.keys(universalResultsConfig).map(key => {
     return {
+      Layout: StandardLayout,
       path: `/${key}`,
       page: <VerticalSearchPage verticalKey={key} />
     }
@@ -30,7 +37,6 @@ export default function App() {
     >
       <div className='App'>
         <PageRouter
-          Layout={StandardLayout}
           routes={routes}
         />
       </div>

--- a/sample-app/src/PageRouter.tsx
+++ b/sample-app/src/PageRouter.tsx
@@ -2,6 +2,7 @@ import { ComponentType } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 interface RouteData {
+  Layout?: LayoutComponent,
   path: string,
   page: JSX.Element,
   exact?: boolean
@@ -10,7 +11,6 @@ interface RouteData {
 export type LayoutComponent = ComponentType<{ page: JSX.Element }>
 
 interface PageProps {
-  Layout?: LayoutComponent,
   routes: RouteData[]
 }
 
@@ -18,9 +18,9 @@ interface PageProps {
  * PageRouter abstracts away logic surrounding react-router, and provides an easy way
  * to specify a {@link LayoutComponent} for a page.
  */
-export default function PageRouter({ Layout, routes }: PageProps) {
+export default function PageRouter({ routes }: PageProps) {
   const pages = routes.map(routeData => {
-    const { path, page, exact } = routeData;
+    const { Layout, path, page, exact } = routeData;
     if (Layout) {
       return (
         <Route key={path} path={path} exact={exact}>

--- a/sample-app/src/components/ProgressBar.tsx
+++ b/sample-app/src/components/ProgressBar.tsx
@@ -1,0 +1,12 @@
+import '../sass/ProgressBar.scss';
+
+export default function ProgressBar(props: { completePercentage: number }): JSX.Element {
+  const { completePercentage } = props;
+  return (
+    <div className='ProgressBar'>
+      <div className='ProgressBar__bar'>
+        <div style={{ width: `${completePercentage}%` }} className='ProgressBar__percentage'></div>
+      </div>
+    </div>
+  );
+}

--- a/sample-app/src/components/Prompts.tsx
+++ b/sample-app/src/components/Prompts.tsx
@@ -1,0 +1,69 @@
+
+import { Children, cloneElement, isValidElement, useState } from 'react';
+import ProgressBar from "../components/ProgressBar";
+import { useAnswersActions } from '@yext/answers-headless-react';
+import { Option } from './promptcards/StandardPrompt';
+import StandardPrompt from './promptcards/StandardPrompt';
+import { executeSearch } from '../utils/search-operations';
+import { useHistory } from 'react-router';
+
+interface Props {
+  constructQueryFn: (options: Option[][]) => string,
+  verticalKey?: string
+}
+
+export default function Prompts(props: React.PropsWithChildren<Props>): JSX.Element | null {
+  const { children, constructQueryFn, verticalKey } = props;
+  const childrenArray = Children.toArray(children);
+  const [ currentPromptIndex, updatePromptIndex ] = useState(0);
+  const [ promptSelectedOptions, updatePromptSelectedOptions ] 
+    = useState<Option[][]>(Array(childrenArray.length).fill([]));
+  const answersActions = useAnswersActions();
+  const history = useHistory();
+
+  const onClickPrevious = () => {
+    updatePromptIndex(currentPromptIndex-1);
+  }
+  const onClickNext = () => {
+    updatePromptIndex(currentPromptIndex+1);
+  }
+  const onClickSubmit = () => {
+    executeSearch(answersActions, !!verticalKey);
+    verticalKey
+      ? history.push(`/${verticalKey}`)
+      : history.push('/');
+  }
+
+  const child = childrenArray[currentPromptIndex];
+  let prompt = child;
+  if (isValidElement(child) && child.type === StandardPrompt) {
+    const modifiedOnClickOption = (options: Option[]) => {
+      child.props.onSelectedOptionUpdate?.(options);
+      promptSelectedOptions[currentPromptIndex] = options;
+      updatePromptSelectedOptions(promptSelectedOptions);
+      answersActions.setQuery(constructQueryFn(promptSelectedOptions));
+    }
+    prompt = cloneElement(child, {
+      preSelectedOptions: promptSelectedOptions[currentPromptIndex],
+      onSelectedOptionUpdate: modifiedOnClickOption
+    });
+  }
+
+  return (
+    <div>
+      <ProgressBar 
+        completePercentage={currentPromptIndex/(childrenArray.length-1) * 100}
+      />
+      {prompt}
+      {currentPromptIndex !== 0 &&
+        <button onClick={onClickPrevious}>Previous</button>
+      }
+      {currentPromptIndex !== childrenArray.length-1 &&
+        <button onClick={onClickNext}>Next</button>
+      }
+      {currentPromptIndex === childrenArray.length-1 &&
+        <button onClick={onClickSubmit}>Submit</button>
+      }
+    </div>
+  );
+}

--- a/sample-app/src/components/SearchBar.tsx
+++ b/sample-app/src/components/SearchBar.tsx
@@ -18,7 +18,8 @@ interface Props {
   placeholder?: string,
   isVertical: boolean,
   geolocationOptions?: PositionOptions,
-  screenReaderInstructionsId: string
+  screenReaderInstructionsId: string,
+  onExecuteSearch?: () => void
 }
 
 /**
@@ -28,7 +29,8 @@ export default function SearchBar({
   placeholder,
   isVertical,
   geolocationOptions,
-  screenReaderInstructionsId
+  screenReaderInstructionsId,
+  onExecuteSearch=()=>{}
 }: Props) {
   const answersActions = useAnswersActions();
   const query = useAnswersState(state => state.query.input);
@@ -61,6 +63,7 @@ export default function SearchBar({
       await updateLocationIfNeeded(answersActions, intents, geolocationOptions);
     }
     executeSearch(answersActions, isVertical);
+    onExecuteSearch();
   }
 
   function renderSearchButton () {

--- a/sample-app/src/components/promptcards/StandardPrompt.tsx
+++ b/sample-app/src/components/promptcards/StandardPrompt.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import '../../sass/Prompt.scss';
+import classNames from "classnames";
+
+export interface Option {
+  value: string
+}
+
+export interface StandardPromptProps {
+  question: string,
+  options?: Option[],
+  onlyOneSelected: boolean,
+  preSelectedOptions?: Option[],
+  onSelectedOptionUpdate?: (options: Option[]) => void
+}
+
+export default function StandardPrompt(props: StandardPromptProps): JSX.Element | null {
+  const { question, options, onSelectedOptionUpdate=() => {}, onlyOneSelected, preSelectedOptions=[] } = props;
+  const [selectedOptions, updateSelectedOptions] = useState<Option[]>(preSelectedOptions);
+  if (!options) {
+    return null;
+  }
+  
+  const onOptionClick = (option: Option) => {
+    let newSelectedOptions;
+    if (selectedOptions.includes(option)) { //unselect
+      newSelectedOptions = selectedOptions.filter(selectedOption => selectedOption !== option);
+      updateSelectedOptions(newSelectedOptions);
+    } else { //select
+      if (onlyOneSelected) {
+        newSelectedOptions = [option];
+        updateSelectedOptions(newSelectedOptions);
+      } else {
+        newSelectedOptions = [...selectedOptions, option];
+        updateSelectedOptions(newSelectedOptions);
+      }
+    }
+    onSelectedOptionUpdate(newSelectedOptions);
+  }
+  return (
+    <div className='StandardPrompt'>
+      <div>{question}</div>
+      <div>
+        {options.map((option, index) => {
+          const cssClasses = classNames('Prompt__option', { 'Prompt__optionHighlight': selectedOptions.includes(option) });
+          return <div className={cssClasses} key={index} onClick={() => {onOptionClick(option)}}>{option.value}</div>
+        })}
+      </div>
+    </div>
+  );
+}

--- a/sample-app/src/pages/GuidedSearchPage.tsx
+++ b/sample-app/src/pages/GuidedSearchPage.tsx
@@ -1,0 +1,51 @@
+
+import SearchBar from "../components/SearchBar";
+import Prompts from "../components/Prompts";
+import StandardPrompt from "../components/promptcards/StandardPrompt";
+import { Option } from "../components/promptcards/StandardPrompt";
+import { useHistory } from 'react-router';
+
+export default function GuidedSearchPage(props: {
+  verticalKey?: string
+}) {
+  const { verticalKey } = props; 
+  const history = useHistory();
+  return (
+    <div className='GuidedSearchPage'>
+      <SearchBar
+        placeholder='Search...'
+        isVertical={!!verticalKey}
+        screenReaderInstructionsId='SearchBar__srInstructions'
+        onExecuteSearch={() => {
+          verticalKey
+            ? history.push(`/${verticalKey}`)
+            : history.push('/');
+        }}
+      />
+      <Prompts
+        verticalKey={verticalKey}
+        constructQueryFn={(options: Option[][]) => {
+          return options?.flatMap(aPromptOptions => {
+            return aPromptOptions?.map(option => option.value).join(', ');
+          }).filter(options => !!options).join(' and ');
+        }}
+      >
+        <StandardPrompt 
+          question='What country are they located in?'
+          options={[{ value: 'Canada' }, { value: 'US' }, { value: 'Remote' }]}
+          onlyOneSelected={true}
+        />
+        <StandardPrompt 
+          question='What department(s) are they in?'
+          options={[{ value: 'Technology' }, { value: 'Product' }, { value: 'Sale Operations' }]}
+          onlyOneSelected={false}
+        />
+        <StandardPrompt 
+          question='What language(s) do they speak?'
+          options={[{ value: 'Japanese' }, { value: 'English' }, { value: 'Spanish' }]}
+          onlyOneSelected={false}
+        />
+      </Prompts>
+    </div>
+  )
+}

--- a/sample-app/src/sass/ProgressBar.scss
+++ b/sample-app/src/sass/ProgressBar.scss
@@ -1,0 +1,16 @@
+.ProgressBar {
+  height: 20px;
+  margin: 10px;
+
+  &__bar {
+    height: inherit;
+    background-color: #e0e0de;
+    width: 100%;
+  }
+
+  &__percentage {
+    height: 100%;
+    width: 0%;
+    background-color: coral;
+  }
+}

--- a/sample-app/src/sass/Prompt.scss
+++ b/sample-app/src/sass/Prompt.scss
@@ -1,0 +1,10 @@
+.Prompt {
+
+  &__option {
+    cursor: pointer;
+  }
+
+  &__optionHighlight {
+    background-color: coral;
+  }
+}


### PR DESCRIPTION
Changes:
- Added GuidedSearchPage to display a search bar and prompts component
- Added ProgressBar component
- Added Prompts component that display one prompt at a time (only have StandardPrompt template for now), with navigation button to move to previous/next prompt, or submit and get navigate to a normal universal/vertical search page with results based on the constructed query from the prompts.
- Modify PageRouter to include custom layout for individual pages, and added /prompt route

Notes:
- PageRouter currently takes in a single Layout for all pages. To increase customization flexibility, each page provide its own layout instead.
- Possibly consider adding a callback function in SearchBar so other components may run custom logic for when a search is executed (e.g. navigate to another page on search).

J=SLAP-1734
TEST=manual