### PR TITLE
Multi-filterSearch redirect to result page

### DIFF
--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -1,6 +1,8 @@
 import './sass/App.scss';
 import VerticalSearchPage from './pages/VerticalSearchPage';
 import UniversalSearchPage from './pages/UniversalSearchPage';
+import FilterSearchPage from './pages/FilterSearchPage';
+import FilterSearchResultsPage from './pages/FilterSearchResultsPage';
 import PageRouter from './PageRouter';
 import StandardLayout from './pages/StandardLayout';
 import { AnswersHeadlessProvider } from '@yext/answers-headless-react';
@@ -10,12 +12,22 @@ const routes = [
   {
     path: '/',
     exact: true,
-    page: <UniversalSearchPage universalResultsConfig={universalResultsConfig} />
+    page: <UniversalSearchPage universalResultsConfig={universalResultsConfig} />,
+    Layout: StandardLayout
+  },
+  {
+    path: '/filter-search-page',
+    page: <FilterSearchPage verticalKey='people' />
+  },
+  {
+    path: '/filter-search-results-page',
+    page: <FilterSearchResultsPage verticalKey='people' />
   },
   ...Object.keys(universalResultsConfig).map(key => {
     return {
       path: `/${key}`,
-      page: <VerticalSearchPage verticalKey={key} />
+      page: <VerticalSearchPage verticalKey={key} />,
+      Layout: StandardLayout
     }
   })
 ];
@@ -31,7 +43,6 @@ export default function App() {
     >
       <div className='App'>
         <PageRouter
-          Layout={StandardLayout}
           routes={routes}
         />
       </div>

--- a/sample-app/src/PageRouter.tsx
+++ b/sample-app/src/PageRouter.tsx
@@ -4,13 +4,13 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 interface RouteData {
   path: string,
   page: JSX.Element,
-  exact?: boolean
+  exact?: boolean,
+  Layout?: LayoutComponent
 }
 
 export type LayoutComponent = ComponentType<{ page: JSX.Element }>
 
 interface PageProps {
-  Layout?: LayoutComponent,
   routes: RouteData[]
 }
 
@@ -18,9 +18,9 @@ interface PageProps {
  * PageRouter abstracts away logic surrounding react-router, and provides an easy way
  * to specify a {@link LayoutComponent} for a page.
  */
-export default function PageRouter({ Layout, routes }: PageProps) {
+export default function PageRouter({ routes }: PageProps) {
   const pages = routes.map(routeData => {
-    const { path, page, exact } = routeData;
+    const { path, page, exact, Layout } = routeData;
     if (Layout) {
       return (
         <Route key={path} path={path} exact={exact}>

--- a/sample-app/src/components/LocationFilterSearch.tsx
+++ b/sample-app/src/components/LocationFilterSearch.tsx
@@ -98,52 +98,50 @@ export default function LocationFilterSearch ({
   return (
     <div className='FilterSearch'>
       <h1>{title}</h1>
-      <div className='FilterSearch__searchContainter'>
-        <InputDropdown
-          inputValue={input}
-          placeholder='this is filter search...'
-          screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-          screenReaderInstructionsId={screenReaderInstructionsId}
-          screenReaderText={screenReaderText}
-          onlyAllowDropdownOptionSubmissions={true}
-          onInputChange={newInput => {
-            setInput(newInput);
-          }}
-          onInputFocus={(input) => {
-            executeFilterSearch(input);
-          }}
-          cssClasses={cssClasses}
-        >
-          {sections.map((section, sectionIndex) => {
-            return (
-              <DropdownSection
-                key={`Autocomplete__section-${sectionIndex}`}
-                options={section.results}
-                optionIdPrefix={`Autocomplete__option-${sectionIndex}`}
-                onFocusChange={value => {
-                  setInput(value);
-                }}
-                onSelectOption={(optionValue, optionIndex) => {
-                  setInput(optionValue);
-                  const result = filterSearchResponse?.sections[sectionIndex].results[optionIndex];
-                  onSelectOption(optionValue, result?.filter);
-                  if (result?.filter) {
-                    if (selectedFilterOptionRef.current) {
-                      answersActions.setFilterOption({ ...selectedFilterOptionRef.current, selected: false });
-                    }
-                    selectedFilterOptionRef.current = result.filter;
-                    answersActions.setFilterOption({ ...result.filter, selected: true });
-                    answersActions.executeVerticalQuery();
+      <InputDropdown
+        inputValue={input}
+        placeholder='this is filter search...'
+        screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
+        screenReaderInstructionsId={screenReaderInstructionsId}
+        screenReaderText={screenReaderText}
+        onlyAllowDropdownOptionSubmissions={true}
+        onInputChange={newInput => {
+          setInput(newInput);
+        }}
+        onInputFocus={(input) => {
+          executeFilterSearch(input);
+        }}
+        cssClasses={cssClasses}
+      >
+        {sections.map((section, sectionIndex) => {
+          return (
+            <DropdownSection
+              key={`Autocomplete__section-${sectionIndex}`}
+              options={section.results}
+              optionIdPrefix={`Autocomplete__option-${sectionIndex}`}
+              onFocusChange={value => {
+                setInput(value);
+              }}
+              onSelectOption={(optionValue, optionIndex) => {
+                setInput(optionValue);
+                const result = filterSearchResponse?.sections[sectionIndex].results[optionIndex];
+                onSelectOption(optionValue, result?.filter);
+                if (result?.filter) {
+                  if (selectedFilterOptionRef.current) {
+                    answersActions.setFilterOption({ ...selectedFilterOptionRef.current, selected: false });
                   }
-                }}
-                label={section.label}
-                cssClasses={cssClasses}
-              />
-            );
-          })}
-        </InputDropdown>
-        <button onClick={onGetUserLocation}>get user location</button>
-      </div>
+                  selectedFilterOptionRef.current = result.filter;
+                  answersActions.setFilterOption({ ...result.filter, selected: true });
+                  answersActions.executeVerticalQuery();
+                }
+              }}
+              label={section.label}
+              cssClasses={cssClasses}
+            />
+          );
+        })}
+      </InputDropdown>
+      <button onClick={onGetUserLocation}>get user location</button>
     </div>
   );
 }

--- a/sample-app/src/pages/FilterSearchPage.tsx
+++ b/sample-app/src/pages/FilterSearchPage.tsx
@@ -3,7 +3,7 @@ import { useAnswersActions, Filter } from '@yext/answers-headless-react';
 import FilterSearch from '../components/FilterSearch';
 import LocationFilterSearch from '../components/LocationFilterSearch';
 import '../sass/FilterSearchPage.scss';
-import { useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 const filterSearchNameField = [{
   fieldApiName: 'name',
@@ -34,8 +34,10 @@ export interface FilterSeachPageLocationParams {
 export default function FilterSearchPage(props: { verticalKey: string }) {
   const { verticalKey } = props;
   const answersActions = useAnswersActions();
-  answersActions.setStaticFilters([]);
-  answersActions.setVerticalKey(verticalKey);
+  useLayoutEffect(() => {
+    answersActions.setStaticFilters([]);
+    answersActions.setVerticalKey(verticalKey);
+  });
   const history = useHistory();
   const selectedOptionRef = useRef<FilterSeachPageLocationParams>({
     filterSearchNameOption: null,

--- a/sample-app/src/pages/FilterSearchPage.tsx
+++ b/sample-app/src/pages/FilterSearchPage.tsx
@@ -1,0 +1,111 @@
+import { useHistory } from 'react-router';
+import { useAnswersActions, Filter } from '@yext/answers-headless-react';
+import FilterSearch from '../components/FilterSearch';
+import LocationFilterSearch from '../components/LocationFilterSearch';
+import '../sass/FilterSearchPage.scss';
+import { useRef } from 'react';
+
+const filterSearchNameField = [{
+  fieldApiName: 'name',
+  entityType: 'ce_person'
+}];
+
+const filterSearchLocationField = [{
+  fieldApiName: 'builtin.location',
+  entityType: 'ce_person'
+}];
+
+const filterSearchLanguageField = [{
+  fieldApiName: 'languages',
+  entityType: 'ce_person'
+}];
+
+interface SelectedFilterSearchOption {
+  optionValue: string,
+  filter: Filter|undefined
+}
+
+export interface FilterSeachPageLocationParams {
+  filterSearchNameOption: SelectedFilterSearchOption | null,
+  filterSearchLocationOption: SelectedFilterSearchOption | null,
+  filterSearchLanguageOption: SelectedFilterSearchOption | null
+}
+
+export default function FilterSearchPage(props: { verticalKey: string }) {
+  const { verticalKey } = props;
+  const answersActions = useAnswersActions();
+  answersActions.setStaticFilters([]);
+  answersActions.setVerticalKey(verticalKey);
+  const history = useHistory();
+  const selectedOptionRef = useRef<FilterSeachPageLocationParams>({
+    filterSearchNameOption: null,
+    filterSearchLocationOption: null,
+    filterSearchLanguageOption: null,
+  }); 
+
+  const onSubmit = () => {
+    answersActions.setQuery('');
+    answersActions.executeVerticalQuery();
+    history.push({
+      pathname:'/filter-search-results-page',
+      state: selectedOptionRef.current
+    })
+  };
+
+  return (
+    <div className='FilterSearchPage'>
+      <h1 style={{ margin: '100px' }}>Some other website content...</h1>
+      <div className='FilterSearchPage__filtersContainer'>
+        <FilterSearch
+          title='Filter Search for name!'
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchNameOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchNameOption = { optionValue, filter };
+          }}
+          sectioned={false}
+          searchFields={filterSearchNameField}
+          screenReaderInstructionsId='FilterSearch-Name'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <LocationFilterSearch
+          title='Filter Search for location!'
+          inputValue={selectedOptionRef.current.filterSearchLocationOption?.optionValue || ''}
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchLocationOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchLocationOption = { optionValue, filter };
+          }}
+          sectioned={false}
+          searchFields={filterSearchLocationField}
+          screenReaderInstructionsId='FilterSearch-Location'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <FilterSearch
+          title='Filter Search for languages!'
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchLanguageOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchLanguageOption = { optionValue, filter };
+          }}
+          inputValue={selectedOptionRef.current.filterSearchLanguageOption?.optionValue || ''}
+          sectioned={false}
+          searchFields={filterSearchLanguageField}
+          screenReaderInstructionsId='FilterSearch-Language'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <button onClick={onSubmit}>Submit</button>
+      </div>
+      <h1 style={{ margin: '100px' }}>Some other website content...</h1>
+    </div>
+  );
+}

--- a/sample-app/src/pages/FilterSearchResultsPage.tsx
+++ b/sample-app/src/pages/FilterSearchResultsPage.tsx
@@ -1,0 +1,125 @@
+import { useAnswersActions, Filter } from '@yext/answers-headless-react';
+import FilterSearch from '../components/FilterSearch';
+import ResultsCount from '../components/ResultsCount';
+import AlternativeVerticals from '../components/AlternativeVerticals';
+import DecoratedAppliedFilters from '../components/DecoratedAppliedFilters';
+import DirectAnswer from '../components/DirectAnswer';
+import VerticalResults from '../components/VerticalResults';
+import '../sass/FilterSearchPage.scss';
+import { StandardCard } from '../components/cards/StandardCard';
+import { useLocation } from 'react-router';
+import { FilterSeachPageLocationParams } from './FilterSearchPage';
+import { useRef } from 'react';
+import LocationFilterSearch from '../components/LocationFilterSearch';
+
+const filterSearchNameField = [{
+  fieldApiName: 'name',
+  entityType: 'ce_person'
+}];
+
+const filterSearchLocationField = [{
+  fieldApiName: 'builtin.location',
+  entityType: 'ce_person'
+}];
+
+const filterSearchLanguageField = [{
+  fieldApiName: 'languages',
+  entityType: 'ce_person'
+}];
+
+const staticFiltersGroupLabels = {
+  c_employeeCountry: 'Employee Country',
+  c_employeeDepartment: 'Employee Deparment'
+}
+
+
+export default function FilterSearchPageResults(props: { verticalKey: string }) {
+  // const { verticalKey } = props;
+  const answersActions = useAnswersActions();
+  const onSubmit = () => {
+    answersActions.setQuery('');
+    answersActions.executeVerticalQuery();
+  };
+  const location = useLocation<FilterSeachPageLocationParams>();
+  console.log(location.state);
+
+  const selectedOptionRef = useRef<FilterSeachPageLocationParams>(location.state); 
+
+  return (
+    <div className='FilterSearchPage'>
+      <div className='FilterSearchPage__filtersContainer'>
+        <FilterSearch
+          title='Filter Search for name!'
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchNameOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchNameOption = { optionValue, filter };
+          }}
+          inputValue={selectedOptionRef.current.filterSearchNameOption?.optionValue || ''}
+          sectioned={false}
+          searchFields={filterSearchNameField}
+          screenReaderInstructionsId='FilterSearch-Name'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <LocationFilterSearch
+          title='Filter Search for location!'
+          inputValue={selectedOptionRef.current.filterSearchLocationOption?.optionValue || ''}
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchLocationOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchLocationOption = { optionValue, filter };
+          }}
+          sectioned={false}
+          searchFields={filterSearchLocationField}
+          screenReaderInstructionsId='FilterSearch-Location'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <FilterSearch
+          title='Filter Search for languages!'
+          onSelectOption={(optionValue: string, filter: Filter|undefined) => {
+            const selectedOptionFilter = selectedOptionRef.current.filterSearchLanguageOption?.filter;
+            selectedOptionFilter &&  answersActions.setFilterOption({ ...selectedOptionFilter, selected: false })
+            selectedOptionRef.current.filterSearchLanguageOption = { optionValue, filter };
+          }}
+          inputValue={selectedOptionRef.current.filterSearchLanguageOption?.optionValue || ''}
+          sectioned={false}
+          searchFields={filterSearchLanguageField}
+          screenReaderInstructionsId='FilterSearch-Language'
+          customCssClasses={{
+            inputElement: 'FilterSearchPage__inputElement',
+            dropdownContainer: 'Autocomplete FilterSearchPage__autocompleteContainter'
+          }}
+        />
+        <button onClick={onSubmit}>Submit</button>
+      </div>
+      <div className="FilterSearchResultsPage__results">
+        <DirectAnswer />
+        <ResultsCount />
+        <DecoratedAppliedFilters
+          showFieldNames={true}
+          hiddenFields={['builtin.entityType']}
+          delimiter='|'
+          staticFiltersGroupLabels={staticFiltersGroupLabels}
+        />
+        <AlternativeVerticals
+          currentVerticalLabel='People'
+          verticalsConfig={[
+            { label: 'Locations', verticalKey: 'KM' },
+            { label: 'FAQs', verticalKey: 'faq' }
+          ]}
+        />
+        <VerticalResults
+          CardComponent={StandardCard}
+          cardConfig={{ showOrdinal: true }}
+          displayAllResults={true}
+        />
+      </div>
+    </div>
+  );
+}

--- a/sample-app/src/pages/FilterSearchResultsPage.tsx
+++ b/sample-app/src/pages/FilterSearchResultsPage.tsx
@@ -9,7 +9,7 @@ import '../sass/FilterSearchPage.scss';
 import { StandardCard } from '../components/cards/StandardCard';
 import { useLocation } from 'react-router';
 import { FilterSeachPageLocationParams } from './FilterSearchPage';
-import { useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import LocationFilterSearch from '../components/LocationFilterSearch';
 
 const filterSearchNameField = [{
@@ -34,8 +34,11 @@ const staticFiltersGroupLabels = {
 
 
 export default function FilterSearchPageResults(props: { verticalKey: string }) {
-  // const { verticalKey } = props;
+  const { verticalKey } = props;
   const answersActions = useAnswersActions();
+  useLayoutEffect(() => {
+    answersActions.setVerticalKey(verticalKey);
+  });
   const onSubmit = () => {
     answersActions.setQuery('');
     answersActions.executeVerticalQuery();

--- a/sample-app/src/sass/FilterSearchPage.scss
+++ b/sample-app/src/sass/FilterSearchPage.scss
@@ -1,0 +1,50 @@
+.FilterSearchPage {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  &__filtersContainer {
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid #dcdcdc;
+    width: 80%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__inputElement {
+    width: 80%;
+    padding-right: 0.5em;
+    padding-left: 0.25em;
+    border: 1px solid #dcdcdc;
+  }
+
+  &__autocompleteContainter {
+    position: absolute;
+    width: 20%;
+  }
+
+  &__locationFilter {
+    display: flex;
+  }
+  
+  .FilterSearch__searchContainter {
+    display: flex;
+  }
+}
+
+button {
+  border: 1px solid #dcdcdc;
+}
+
+.FilterSearchResultsPage {
+  &__results {
+    margin-top: 20px;
+  }
+
+  .FilterSearch__searchContainter {
+    display: flex;
+  }
+}

--- a/sample-app/src/sass/FilterSearchPage.scss
+++ b/sample-app/src/sass/FilterSearchPage.scss
@@ -29,10 +29,6 @@
   &__locationFilter {
     display: flex;
   }
-  
-  .FilterSearch__searchContainter {
-    display: flex;
-  }
 }
 
 button {
@@ -42,9 +38,5 @@ button {
 .FilterSearchResultsPage {
   &__results {
     margin-top: 20px;
-  }
-
-  .FilterSearch__searchContainter {
-    display: flex;
   }
 }


### PR DESCRIPTION
Changes:
- Added two pages: a page with Name, Location, and Language FilterSearch component, with a submit button. When submit, it will redirect to a new result page, containing the same three FilterSearch with the selected options and the corresponding vertical results.
- Added a custom FilterSearch component to accommodate for the button in location filterSearch to get user location and update the input in filtersearch
  - NOTE: getUserLocation provide location coordinates, to get the location name, user would need to user other library, such as react-native-geocoding, with apiKey, to perform the conversion (This is not included in this pr)

Notes:
- Similar to guided search user experience item, may be better if individual page can specify their own layout instead of one layout for entire set of routes in PageRouter.
- Any input changes 
- Headless State currently just group every filters and store as a list. To identify and persist the selected options of each filterSearch component when navigating to another page and displaying the same filter searches, user would need to send state through URL, through react-router history/location.state or some shared context. Not too difficult to implement but they are additional steps.
  - This also require some changes to FilterSearch to get the selected filter option and be able to update the initial input
- Logic that requires input changes (beside initial input) or when to trigger submit to FilterSearch would require copying FilterSearch component and making changes to it. (e.g. a button that gets user location and update filterSearch component input, be able to trigger multiple FilterSearch's setFilterOption call base on a submit button on the page)


J=SLAP-1733
TEST=manual