### PR TITLE
add service-worker caching

### DIFF
--- a/sample-app/config/webpack.config.js
+++ b/sample-app/config/webpack.config.js
@@ -672,8 +672,12 @@ module.exports = function (webpackEnv) {
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       // Generate a service worker script that will precache, and keep up to date,
       // the HTML & assets that are part of the webpack build.
-      isEnvProduction &&
-        fs.existsSync(swSrc) &&
+      /**
+       * @remarks
+       * CRA by default does not build service workers in dev mode.
+       * We do, because we have custom logic for caching API requests.
+       */
+      fs.existsSync(swSrc) &&
         new WorkboxWebpackPlugin.InjectManifest({
           swSrc,
           dontCacheBustURLsMatching: /\.[0-9a-f]{8}\./,

--- a/sample-app/src/components/VisualAutocomplete/SampleVisualSearchBar.tsx
+++ b/sample-app/src/components/VisualAutocomplete/SampleVisualSearchBar.tsx
@@ -11,7 +11,7 @@ export default function SampleVisualSearchBar() {
       placeholder='Search...'
       screenReaderInstructionsId='SearchBar__srInstructions'
       headlessId='visual-autocomplete'
-      entityPreviewsDebouncingTime={150}
+      entityPreviewsDebouncingTime={100}
       renderEntityPreviews={isLoading => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='people'>

--- a/sample-app/src/index.tsx
+++ b/sample-app/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './tailwind.css';
 import './sass/index.scss';
 import App from './App';
+import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -11,3 +12,4 @@ ReactDOM.render(
   document.getElementById('root')
 );
 
+registerServiceWorker();

--- a/sample-app/src/registerServiceWorker.ts
+++ b/sample-app/src/registerServiceWorker.ts
@@ -1,0 +1,6 @@
+export default function registerServiceWorker() {
+  window.addEventListener('load', () => {
+    const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+    navigator.serviceWorker.register(swUrl)
+  });
+}

--- a/sample-app/src/service-worker.ts
+++ b/sample-app/src/service-worker.ts
@@ -1,0 +1,71 @@
+/// <reference lib="webworker" />
+import { clientsClaim } from 'workbox-core';
+import { precacheAndRoute } from 'workbox-precaching';
+
+declare const self: ServiceWorkerGlobalScope;
+
+clientsClaim();
+const precacheManifest = self.__WB_MANIFEST;
+// Only precache static assets in production.
+// Precaching in development can result in confusing situations.
+// See https://github.com/facebook/create-react-app/issues/2398#issuecomment-304638935
+if (process.env.NODE_ENV !== 'development') {
+  precacheAndRoute(precacheManifest);
+}
+
+const cacheName = 'YEXT_ANSWERS_CACHE';
+const universalSearch = /v2\/accounts\/me\/answers\/query/;
+const universalAutocomplete = /v2\/accounts\/me\/answers\/autocomplete/;
+const verticalAutocomplete = /v2\/accounts\/me\/answers\/vertical\/autocomplete/;
+const swFetchedOnHeader = 'yxt-sw-fetched-on';
+
+// Clear the cache when a new service worker activates
+self.addEventListener('activate', event => {
+  event.waitUntil(caches.delete(cacheName));
+});
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  // Only cache universal search requests intended for VisualAutocomplete
+  if (
+    universalSearch.test(event.request.url) &&
+    new URLSearchParams(event.request.url).has('restrictVerticals')
+  ) {
+    event.respondWith(respondUsingCache(event.request, 30 * 1000));
+  }
+
+  if ([universalAutocomplete, verticalAutocomplete].find(regex => regex.test(event.request.url))) {
+    event.respondWith(respondUsingCache(event.request, 30 * 1000));
+  }
+});
+
+async function respondUsingCache(request: Request, timeToLiveInMilliseconds: number): Promise<Response> {
+  const cachedResponse = await caches.match(request);
+  const fetchedOn = cachedResponse?.headers.get(swFetchedOnHeader);
+  if (cachedResponse && fetchedOn) {
+    try {
+      const fetchedOnTimestamp = parseInt(fetchedOn);
+      const currentTimestamp = new Date().getTime();
+      if (currentTimestamp < fetchedOnTimestamp + timeToLiveInMilliseconds) {
+        return cachedResponse;
+      }
+    } catch (e) {
+      console.error(`Service worker could not parse ${swFetchedOnHeader} header with value "${fetchedOn}".`);
+    }
+  }
+
+  const [cache, freshResponse] = await Promise.all<Cache, Response>([
+    caches.open(cacheName),
+    fetch(request)
+  ]);
+  const clone = freshResponse.clone();
+  const headers = new Headers(freshResponse.headers);
+  headers.append(swFetchedOnHeader, new Date().getTime().toString());
+  const body = await clone.blob();
+  const responseToCache = new Response(body, {
+    status: clone.status,
+    statusText: clone.statusText,
+    headers
+  });
+  await cache.put(request, responseToCache);
+  return freshResponse;
+}


### PR DESCRIPTION
This commit adds service worker caching for
universal search, universal autocomplete, and vertical autocomplete.
The VisualAutocomplete spec only called for caching of
universal search, however it's really simple to add additional caching
for the 2 autocompletes, and makes the experience feel very snappy.

Talked with Rose and we somewhat arbitrarily chose 30 seconds.
There should be no issues with caching anything autocomplete related
since we don't charge for autocomplete. However, universal searches
not made for VisualAutocomplete should not be cached.

J=SLAP-1729
TEST=manual

universal searches made for entity previews, and regular autocomplete
requests were both cached, by going into the network tab and seeing ~1-2ms response
times and the Size column saying "(ServiceWorker")

cache expiration works as expected, and will expire after 30 seconds

regular universal searches were never cached

there's a bug right now in VisualSearchBar where if you have no recent
searches, but hit the down arrow, the whole app crashes