### PR TITLE
Connected Searchbars Experience

### DIFF
--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -2,11 +2,11 @@ import UniversalSearchPage from './pages/UniversalSearchPage';
 import FAQsPage from './pages/FAQsPage';
 import EventsPage from './pages/EventsPage';
 import PageRouter from './PageRouter';
-import StandardLayout from './pages/StandardLayout';
 import { AnswersHeadlessProvider } from '@yext/answers-headless-react';
 import { universalResultsConfig } from './universalResultsConfig';
 import JobsPage from './pages/JobsPage';
 import LocationsPage from './pages/LocationsPage';
+import ConnectedSearchBarsLayout from './pages/ConnectedSearchBarsLayout';
 
 const routes = [
   {
@@ -43,7 +43,7 @@ export default function App() {
       <div className='flex justify-center px-8 py-6'>
         <div className='w-full max-w-5xl'>
           <PageRouter
-            Layout={StandardLayout}
+            Layout={ConnectedSearchBarsLayout}
             routes={routes}
           />
         </div>

--- a/sample-app/src/components/VisualAutocomplete/SampleVisualSearchBar.tsx
+++ b/sample-app/src/components/VisualAutocomplete/SampleVisualSearchBar.tsx
@@ -1,4 +1,4 @@
-import VisualSearchBar from './VisualSearchBar';
+import VisualSearchBar, { VisualSearchBarCssClasses } from './VisualSearchBar';
 import { Result } from '@yext/answers-headless-react';
 import EntityPreviews from './EntityPreviews';
 import { universalResultsConfig } from '../../universalResultsConfig';
@@ -6,12 +6,24 @@ import { universalResultsConfig } from '../../universalResultsConfig';
 /**
  * This is an example of how to use the VisualSearchBar component.
  */
-export default function SampleVisualSearchBar() {
+export default function SampleVisualSearchBar(
+  { searchBarId,
+    onSubmit=() => {},
+    customCssClasses
+  }: { 
+    searchBarId?: string,
+    onSubmit?: (value: string|undefined) => void,
+    customCssClasses?: VisualSearchBarCssClasses
+  }
+) {
   return (
     <VisualSearchBar
       placeholder='Search...'
+      onSubmit={onSubmit}
+      searchBarId={searchBarId}
       screenReaderInstructionsId='SearchBar__srInstructions'
       headlessId='visual-autocomplete'
+      customCssClasses={customCssClasses}
       entityPreviewsDebouncingTime={100}
       verticalKeyToLabel={verticalKey => universalResultsConfig[verticalKey]?.label ?? verticalKey}
       renderEntityPreviews={isLoading => (

--- a/sample-app/src/components/contexts/SearchbarsContext.ts
+++ b/sample-app/src/components/contexts/SearchbarsContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ConnectedSearchBarsContext = createContext<{searchBarsInput: Record<string, string> }>({ searchBarsInput: {} });

--- a/sample-app/src/pages/ConnectedSearchBarsLayout.tsx
+++ b/sample-app/src/pages/ConnectedSearchBarsLayout.tsx
@@ -1,0 +1,78 @@
+import Navigation from '../components/Navigation';
+import { useAnswersState } from '@yext/answers-headless-react';
+import { universalResultsConfig } from '../universalResultsConfig';
+import { LayoutComponent } from '../PageRouter';
+import SearchBar from '../components/SearchBar';
+import SampleVisualSearchBar from '../components/VisualAutocomplete/SampleVisualSearchBar';
+import { useContext, useReducer } from 'react';
+import { ConnectedSearchBarsContext } from '../components/contexts/SearchbarsContext';
+
+const navLinks = [
+  {
+    to: '/',
+    label: 'All'
+  },
+  ...Object.entries(universalResultsConfig).map(([verticalKey, config]) => ({
+    to: verticalKey,
+    label: config.label || verticalKey
+  }))
+]
+
+/**
+ * A LayoutComponent that provides a SearchBar and Navigation tabs to a given page.
+ */
+const ConnectedSearchBarsLayout: LayoutComponent = ({ page }) => {
+  const isVertical = useAnswersState(state => !!state.vertical.verticalKey);
+  const { searchBarsInput } = useContext(ConnectedSearchBarsContext);
+  const [_, forceUpdate] = useReducer(x => !x, false);
+
+  return (
+    <>
+      <ConnectedSearchBarsContext.Provider value={{ searchBarsInput }}>
+        {isVertical
+          ? <SearchBar
+            onSubmit={(value: string|undefined) => {
+              if (value) {
+                searchBarsInput['main-experience-searchbar'] = value;
+                forceUpdate();
+              }
+            }}
+            customCssClasses={{
+              container: 'w-5/12 h-8 mb-20 ml-auto'
+            }}
+            placeholder='Search...'
+            isVertical={isVertical}
+            screenReaderInstructionsId='SearchBar__srInstructions'
+            searchBarId='top-right-searchbar'
+          />
+          : <SampleVisualSearchBar 
+            searchBarId='top-right-searchbar'
+            onSubmit={(value: string|undefined) => {
+              if (value) {
+                searchBarsInput['main-experience-searchbar'] = value;
+                forceUpdate();
+              }
+            }}
+            customCssClasses={{
+              container: 'w-5/12 h-8 mb-20 ml-auto'
+            }}
+          />
+        }
+        {isVertical
+          ? <SearchBar
+            placeholder='Search...'
+            isVertical={isVertical}
+            screenReaderInstructionsId='SearchBar__srInstructions'
+            searchBarId='main-experience-searchbar'
+          />
+          : <SampleVisualSearchBar 
+            searchBarId='main-experience-searchbar'
+          />
+        }
+      </ConnectedSearchBarsContext.Provider>
+      <Navigation links={navLinks} />
+      {page}
+    </>
+  )
+}
+export default ConnectedSearchBarsLayout;


### PR DESCRIPTION
Changes:
- Used context to provide a shared state of search bar inputs so top-right search bar can manipulate the other search bar
- Updated SearchBar/VisualSearchBar to maintain a separate input value instead of directly use on query in headless state
- css styling
- new layout to have two search bars on page

Notes:
- input value in SearchBar/VisualSearchBar currently directly display query store in state. This makes it difficult to differentiate the input values between difference instances of SearchBar/VisualSearchBar (e.g. any keystroke that update query will update every searchbar instances). Instead, SearchBar/VisualSearchBar may have a separate input value maintain in component state that updates in tandem to executeQuery calls corresponding to that specific instances.
- In order for top-right search bar to update the other main-experience search bar under specific conditions (e.g. on executed search, and only one update the other and not vice versa), the search bar input must be able to be modify outside of its own instance. So, search bar would need to change so that it also consider input updates in a share context.


J=SLAP-1731
TEST=manual

- See that there's two searchbars in universal/vertical pages
- See that executed query in main-experience search bar does not affect the top-right search bar. See the corresponding results on page.
- See that executed query in top-right search bar updated the query in main-expeirence search bar. See the corresponding results loaded on page.