### PR TITLE
Update generate license file library

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -100,47 +100,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-headless-react@0.10.0
-
-This package contains the following license and notice below:
-
-The Answers Headless React files listed in this repository are licensed under the below license. All other features and products are subject to 
-separate agreements and certain functionality requires paid subscriptions to Yext products.
-
-BSD 3-Clause License
-
-Copyright (c) 2021, Yext
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------------
-
-The following NPM package may be included in this product:
-
  - @yext/answers-headless@0.10.0
 
 This package contains the following license and notice below:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-react-perf": "^3.3.1",
-        "generate-license-file": "^1.2.0",
+        "generate-license-file": "^1.3.0",
         "jest": "^27.4.5",
         "msw": "^0.36.3",
         "react": "^17.0.2",
@@ -5026,6 +5026,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz",
@@ -5918,14 +5930,15 @@
       "dev": true
     },
     "node_modules/generate-license-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-license-file/-/generate-license-file-1.2.0.tgz",
-      "integrity": "sha512-P3ePGefBP1NAh4IXtMm3nbyWyJ0pvZiJkYpWgqz1/L4+Zh+oLUoaGlVG+ZnnQ7KnOO8Hy2KwPIzMJ0oYb+HUEw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/generate-license-file/-/generate-license-file-1.3.0.tgz",
+      "integrity": "sha512-UH5zYE5aeEcVcqAzSJdjB4oHkRSX/EkQgHg6tuvo3poxs56KwIC0oGZf4dD6YvsDvFbhAhsa1g6lE9tiUC12Ig==",
       "dev": true,
       "dependencies": {
         "arg": "^4.1.3",
         "cli-spinners": "^2.6.0",
         "enquirer": "^2.3.6",
+        "eslint-config-prettier": "^8.3.0",
         "esm": "^3.2.25",
         "glob": "^7.1.7",
         "inquirer": "^7.3.3",
@@ -15258,6 +15271,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz",
@@ -15794,14 +15814,15 @@
       "dev": true
     },
     "generate-license-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-license-file/-/generate-license-file-1.2.0.tgz",
-      "integrity": "sha512-P3ePGefBP1NAh4IXtMm3nbyWyJ0pvZiJkYpWgqz1/L4+Zh+oLUoaGlVG+ZnnQ7KnOO8Hy2KwPIzMJ0oYb+HUEw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/generate-license-file/-/generate-license-file-1.3.0.tgz",
+      "integrity": "sha512-UH5zYE5aeEcVcqAzSJdjB4oHkRSX/EkQgHg6tuvo3poxs56KwIC0oGZf4dD6YvsDvFbhAhsa1g6lE9tiUC12Ig==",
       "dev": true,
       "requires": {
         "arg": "^4.1.3",
         "cli-spinners": "^2.6.0",
         "enquirer": "^2.3.6",
+        "eslint-config-prettier": "^8.3.0",
         "esm": "^3.2.25",
         "glob": "^7.1.7",
         "inquirer": "^7.3.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "test": "eslint . && jest",
-    "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES"
+    "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
     "@yext/answers-headless": "^0.10.0"
@@ -38,7 +38,7 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-react-perf": "^3.3.1",
-    "generate-license-file": "^1.2.0",
+    "generate-license-file": "^1.3.0",
     "jest": "^27.4.5",
     "msw": "^0.36.3",
     "react": "^17.0.2",


### PR DESCRIPTION
update to use the new version of generate-license-file, which exclude current repo's license in the third-party-notices file

J=SLAP-1754
TEST=manual

ran `npm run generate-notices` with the new version, and see that repo's license is not in the third-party-notices file