### PR TITLE
beta version 1.1.0-beta.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.0-beta.7",
+      "version": "1.1.0-beta.8",
       "dependencies": {
-        "@yext/answers-headless": "^1.1.0-beta.7"
+        "@yext/answers-headless": "^1.1.0-beta.8"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.5",
@@ -3496,9 +3496,9 @@
       }
     },
     "node_modules/@yext/answers-headless": {
-      "version": "1.1.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.7.tgz",
-      "integrity": "sha512-oix72SHiBKfFGv0xb/ChNF1h8sOfduLxpSa3OwuN/sN8wU0KwtbwG9xql7CHXVG8eXSVXw6LOfkIGz5F3NQ65Q==",
+      "version": "1.1.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.8.tgz",
+      "integrity": "sha512-/q0impdy46pAY3KwNE5Pwhns9ANEeMiFGVZzOssc3Lh7B8Di4wEwLn/a4TiTbjx4qa93iEPCZ8LSgRnjP4snAQ==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",
         "@yext/answers-core": "^1.6.0-beta.3",
@@ -13988,9 +13988,9 @@
       }
     },
     "@yext/answers-headless": {
-      "version": "1.1.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.7.tgz",
-      "integrity": "sha512-oix72SHiBKfFGv0xb/ChNF1h8sOfduLxpSa3OwuN/sN8wU0KwtbwG9xql7CHXVG8eXSVXw6LOfkIGz5F3NQ65Q==",
+      "version": "1.1.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.8.tgz",
+      "integrity": "sha512-/q0impdy46pAY3KwNE5Pwhns9ANEeMiFGVZzOssc3Lh7B8Di4wEwLn/a4TiTbjx4qa93iEPCZ8LSgRnjP4snAQ==",
       "requires": {
         "@reduxjs/toolkit": "^1.7.0",
         "@yext/answers-core": "^1.6.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "module": "./lib/index.js",
@@ -16,7 +16,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/answers-headless": "^1.1.0-beta.7"
+    "@yext/answers-headless": "^1.1.0-beta.8"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.5",


### PR DESCRIPTION
bump beta version to include rejected promise handling in headless new version

J=SLAP-1907
TEST=none