### PR TITLE
Pass Client-SDK agent to Headless

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-core@1.6.0-beta.3
+ - @yext/answers-core@1.6.0-beta.5
 
 This package contains the following license and notice below:
 
@@ -100,7 +100,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-headless@1.1.0-beta.8
+ - @yext/answers-headless@1.1.0-beta.10
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.8",
+  "version": "1.1.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.0-beta.8",
+      "version": "1.1.0-beta.9",
       "dependencies": {
-        "@yext/answers-headless": "^1.1.0-beta.8"
+        "@yext/answers-headless": "^1.1.0-beta.10"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.5",
@@ -3484,24 +3484,24 @@
       }
     },
     "node_modules/@yext/answers-core": {
-      "version": "1.6.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.3.tgz",
-      "integrity": "sha512-pMLcVVlsYYH3FkY2DmuHkdUHq0fCRp4XgT+5/1sI1l958xnGvEEejJs+G9vyryrQ9zTj+f7RSnXBhd2e1wfmfw==",
+      "version": "1.6.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.5.tgz",
+      "integrity": "sha512-HUPnVyBBcK9YBsCemSN6ExqvHwLtKZQHyQe1DsRSZfAL9BjhatfpucGbLcHJ+RtIBBFtqEtTuov86k+gkCX2LA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.1.4"
+        "cross-fetch": "^3.1.5"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@yext/answers-headless": {
-      "version": "1.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.8.tgz",
-      "integrity": "sha512-/q0impdy46pAY3KwNE5Pwhns9ANEeMiFGVZzOssc3Lh7B8Di4wEwLn/a4TiTbjx4qa93iEPCZ8LSgRnjP4snAQ==",
+      "version": "1.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.10.tgz",
+      "integrity": "sha512-uW0VI962VKk6JjSCmymr+Lxx/sIL1Fiz54VmgcJnNWmNYNQEKngqY8BThx7vw9gp227U1mmZlbyc40f+7064xw==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.6.0-beta.3",
+        "@yext/answers-core": "^1.6.0-beta.5",
         "js-levenshtein": "^1.1.6",
         "redux-thunk": "^2.4.1"
       }
@@ -13979,21 +13979,21 @@
       "dev": true
     },
     "@yext/answers-core": {
-      "version": "1.6.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.3.tgz",
-      "integrity": "sha512-pMLcVVlsYYH3FkY2DmuHkdUHq0fCRp4XgT+5/1sI1l958xnGvEEejJs+G9vyryrQ9zTj+f7RSnXBhd2e1wfmfw==",
+      "version": "1.6.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.5.tgz",
+      "integrity": "sha512-HUPnVyBBcK9YBsCemSN6ExqvHwLtKZQHyQe1DsRSZfAL9BjhatfpucGbLcHJ+RtIBBFtqEtTuov86k+gkCX2LA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.1.4"
+        "cross-fetch": "^3.1.5"
       }
     },
     "@yext/answers-headless": {
-      "version": "1.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.8.tgz",
-      "integrity": "sha512-/q0impdy46pAY3KwNE5Pwhns9ANEeMiFGVZzOssc3Lh7B8Di4wEwLn/a4TiTbjx4qa93iEPCZ8LSgRnjP4snAQ==",
+      "version": "1.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.10.tgz",
+      "integrity": "sha512-uW0VI962VKk6JjSCmymr+Lxx/sIL1Fiz54VmgcJnNWmNYNQEKngqY8BThx7vw9gp227U1mmZlbyc40f+7064xw==",
       "requires": {
         "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.6.0-beta.3",
+        "@yext/answers-core": "^1.6.0-beta.5",
         "js-levenshtein": "^1.1.6",
         "redux-thunk": "^2.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.8",
-  "types": "./lib/index.d.ts",
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
+  "version": "1.1.0-beta.9",
+  "types": "./lib/src/index.d.ts",
+  "main": "./lib/src/index.js",
+  "module": "./lib/src/index.js",
   "files": [
     "lib",
     "src"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf lib/** && tsc",
     "prepublishOnly": "npm run build",
     "watch": "tsc --watch",
     "test": "eslint . && jest",
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/answers-headless": "^1.1.0-beta.8"
+    "@yext/answers-headless": "^1.1.0-beta.10"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.5",

--- a/src/AnswersHeadlessProvider.tsx
+++ b/src/AnswersHeadlessProvider.tsx
@@ -2,6 +2,9 @@ import { ReactChild, ReactChildren } from 'react';
 import { provideAnswersHeadless, AnswersHeadless, HeadlessConfig } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 import acquireSessionId from './utils/acquireSessionId';
+import packageJson from '../package.json';
+
+const { version } = packageJson;
 
 type Props = HeadlessConfig & {
   children?: ReactChildren | ReactChild | (ReactChildren | ReactChild)[],
@@ -11,7 +14,13 @@ type Props = HeadlessConfig & {
 
 export function AnswersHeadlessProvider(props: Props): JSX.Element {
   const { children, verticalKey, sessionTrackingEnabled=true, ...answersConfig } = props;
-  const answers: AnswersHeadless = provideAnswersHeadless(answersConfig);
+  const additionalHttpHeaders = {
+    'Client-SDK': {
+      ANSWERS_HEADLESS_REACT: version
+    }
+  };
+  const answers: AnswersHeadless = provideAnswersHeadless(answersConfig, additionalHttpHeaders);
+
   verticalKey && answers.setVertical(verticalKey);
   answers.setSessionTrackingEnabled(sessionTrackingEnabled);
   if (sessionTrackingEnabled) {

--- a/src/subscribeToStateUpdates.tsx
+++ b/src/subscribeToStateUpdates.tsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentType, useReducer, useEffect, useContext } from 'react';
-import { State } from '@yext/answers-headless/lib/esm/models/state';
+import { State } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 import isShallowEqual from './utils/isShallowEqual';
 

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -1,5 +1,5 @@
 import { useContext, useLayoutEffect, useRef, useState } from 'react';
-import { State } from '@yext/answers-headless/lib/esm/models/state';
+import { State } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 
 export type StateSelector<T> = (s: State) => T;

--- a/tests/useAnswersState.test.tsx
+++ b/tests/useAnswersState.test.tsx
@@ -1,7 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { provideAnswersHeadless, Result } from '@yext/answers-headless';
-import { State } from '@yext/answers-headless/lib/esm/models/state';
+import { provideAnswersHeadless, Result, State } from '@yext/answers-headless';
 import React, { useCallback, useReducer } from 'react';
 import { AnswersHeadlessContext, useAnswersActions, useAnswersState } from '../src';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "resolveJsonModule": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Passes the `ANSWERS_HEADLESS_REACT` agent as part of the Client-SDK header to Headless through `provideAnswersHeadless`.

J=SLAP-1951
TEST=manual

Hook up locally to the starter app and see that requests send the Headless React, Headless, and Core agents as part of the Client-SDK header. Requests to the universal search endpoint made for entity previews only send the Headless and Core agents because the hook uses `provideAnswersHeadless` directly to get an instance of Headless instead of going through the `AnswersHeadlessProvider` component from Headless React.