### PR TITLE
support React 18

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -566,36 +566,6 @@ This package contains the following license and notice below:
 
 The following NPM package may be included in this product:
 
- - use-isomorphic-layout-effect@1.1.2
-
-This package contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Mateusz Burzyński
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
  - webidl-conversions@3.0.1
 
 This package contains the following license and notice below:

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @reduxjs/toolkit@1.7.0
+ - @reduxjs/toolkit@1.8.1
 
 This package contains the following license and notice below:
 
@@ -199,7 +199,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - immer@9.0.7
+ - immer@9.0.14
 
 This package contains the following license and notice below:
 
@@ -403,41 +403,12 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following NPM packages may be included in this product:
 
- - object-assign@4.1.1
+ - react@18.1.0
+ - use-sync-external-store@1.1.0
 
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - react@17.0.2
-
-This package contains the following license and notice below:
+These packages each contain the following license and notice below:
 
 MIT License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.0-122",
+  "version": "1.1.1-alpha-122",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.1-alpha.0-122",
+      "version": "1.1.1-alpha-122",
       "dependencies": {
         "@yext/answers-headless": "^1.1.0-alpha.0-95",
         "use-isomorphic-layout-effect": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.1-alpha-122",
       "dependencies": {
         "@yext/answers-headless": "^1.1.0-alpha.0-95",
-        "use-isomorphic-layout-effect": "^1.1.2",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -11487,19 +11486,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
@@ -20329,12 +20315,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.12",
+  "version": "1.1.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.0-beta.12",
+      "version": "1.1.1-alpha.0",
       "dependencies": {
-        "@yext/answers-headless": "^1.1.0-beta.12",
-        "use-isomorphic-layout-effect": "^1.1.2"
+        "@yext/answers-headless": "^1.1.0-alpha.0-95",
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.5",
@@ -17,10 +18,11 @@
         "@babel/preset-typescript": "^7.16.5",
         "@css-modules-theme/core": "^2.3.0",
         "@testing-library/jest-dom": "^5.16.1",
-        "@testing-library/react": "^12.1.2",
+        "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.0.3",
-        "@types/react": "^17.0.37",
+        "@types/react": "^18.0.9",
+        "@types/use-sync-external-store": "^0.0.3",
         "@types/uuid": "^8.3.3",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
@@ -38,14 +40,14 @@
         "generate-license-file": "^1.3.0",
         "jest": "^27.4.5",
         "msw": "^0.36.3",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
         "ts-jest": "^27.1.1",
         "typescript": "^4.5.4",
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2"
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2803,9 +2805,9 @@
       "dev": true
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0.tgz",
-      "integrity": "sha512-iApo4zS+8kWnIn4xucTDWpqRjDNkXruFIyJQWwThIEIbMj5kwqvbMaQcEgd2a305B68Z+4bvZqAqJSATeddaJA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
       "dependencies": {
         "immer": "^9.0.7",
         "redux": "^4.1.2",
@@ -2813,7 +2815,7 @@
         "reselect": "^4.1.5"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react": "^16.9.0 || ^17.0.0 || ^18",
         "react-redux": "^7.2.1 || ^8.0.0-beta"
       },
       "peerDependenciesMeta": {
@@ -3028,20 +3030,21 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
-      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.2.0.tgz",
+      "integrity": "sha512-Bprbz/SZVONCJy5f7hcihNCv313IJXdYiv0nSJklIs1SQCIHHNlnGNkosSXnGZTmesyGIcBGNppYhXcc11pb7g==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -3233,14 +3236,23 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
+      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.4.tgz",
+      "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -3281,6 +3293,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+      "dev": true
     },
     "node_modules/@types/uuid": {
       "version": "8.3.3",
@@ -6588,9 +6606,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
-      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -9721,6 +9739,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10244,29 +10263,27 @@
       ]
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
+      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.22.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.1.0"
       }
     },
     "node_modules/react-is": {
@@ -10657,13 +10674,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -11482,6 +11498,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -13787,9 +13811,9 @@
       "dev": true
     },
     "@reduxjs/toolkit": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0.tgz",
-      "integrity": "sha512-iApo4zS+8kWnIn4xucTDWpqRjDNkXruFIyJQWwThIEIbMj5kwqvbMaQcEgd2a305B68Z+4bvZqAqJSATeddaJA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
       "requires": {
         "immer": "^9.0.7",
         "redux": "^4.1.2",
@@ -13957,13 +13981,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
-      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.2.0.tgz",
+      "integrity": "sha512-Bprbz/SZVONCJy5f7hcihNCv313IJXdYiv0nSJklIs1SQCIHHNlnGNkosSXnGZTmesyGIcBGNppYhXcc11pb7g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@testing-library/user-event": {
@@ -14147,14 +14172,23 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
+      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.4.tgz",
+      "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/scheduler": {
@@ -14195,6 +14229,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "8.3.3",
@@ -16606,9 +16646,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
-      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA=="
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -18963,7 +19003,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.11.1",
@@ -19347,23 +19388,21 @@
       "dev": true
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
+      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.22.0"
       }
     },
     "react-is": {
@@ -19666,13 +19705,12 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "semver": {
@@ -20296,6 +20334,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
       "requires": {}
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17 || ^18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.0",
+  "version": "1.1.1-alpha.0-122",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.1-alpha.0",
+      "version": "1.1.1-alpha.0-122",
       "dependencies": {
         "@yext/answers-headless": "^1.1.0-alpha.0-95",
         "use-isomorphic-layout-effect": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@yext/answers-headless": "^1.1.0-alpha.0-95",
-    "use-isomorphic-layout-effect": "^1.1.2",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.0-beta.13",
+  "version": "1.1.1-alpha.0",
   "main": "./lib/esm/src/index.js",
   "types": "./lib/esm/src/index.d.ts",
   "exports": {
@@ -21,8 +21,9 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/answers-headless": "^1.1.0-beta.12",
-    "use-isomorphic-layout-effect": "^1.1.2"
+    "@yext/answers-headless": "^1.1.0-alpha.0-95",
+    "use-isomorphic-layout-effect": "^1.1.2",
+    "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.5",
@@ -30,10 +31,11 @@
     "@babel/preset-typescript": "^7.16.5",
     "@css-modules-theme/core": "^2.3.0",
     "@testing-library/jest-dom": "^5.16.1",
-    "@testing-library/react": "^12.1.2",
+    "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.0.3",
-    "@types/react": "^17.0.37",
+    "@types/react": "^18.0.9",
+    "@types/use-sync-external-store": "^0.0.3",
     "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
@@ -51,14 +53,14 @@
     "generate-license-file": "^1.3.0",
     "jest": "^27.4.5",
     "msw": "^0.36.3",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
     "ts-jest": "^27.1.1",
     "typescript": "^4.5.4",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "jest": {
     "bail": 0,
@@ -82,7 +84,7 @@
     ],
     "testEnvironment": "jsdom",
     "testMatch": [
-      "<rootDir>/tests/**/*.(test).ts(x)?"
+      "<rootDir>/tests/useAnswersState.test.tsx"
     ],
     "globals": {
       "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.0-122",
+  "version": "1.1.1-alpha-122",
   "main": "./lib/esm/src/index.js",
   "types": "./lib/esm/src/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.0",
+  "version": "1.1.1-alpha.0-122",
   "main": "./lib/esm/src/index.js",
   "types": "./lib/esm/src/index.d.ts",
   "exports": {
@@ -84,7 +84,7 @@
     ],
     "testEnvironment": "jsdom",
     "testMatch": [
-      "<rootDir>/tests/useAnswersState.test.tsx"
+      "<rootDir>/tests/**/*.(test).ts(x)?"
     ],
     "globals": {
       "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17 || ^18"
   },
   "jest": {
     "bail": 0,

--- a/src/AnswersHeadlessProvider.tsx
+++ b/src/AnswersHeadlessProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactChild, ReactChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import { provideAnswersHeadless, AnswersHeadless, HeadlessConfig } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 import acquireSessionId from './utils/acquireSessionId';
@@ -7,12 +7,11 @@ import packageJson from '../package.json';
 const { version } = packageJson;
 
 type Props = HeadlessConfig & {
-  children?: ReactChildren | ReactChild | (ReactChildren | ReactChild)[],
   verticalKey?: string,
   sessionTrackingEnabled?: boolean
 };
 
-export function AnswersHeadlessProvider(props: Props): JSX.Element {
+export function AnswersHeadlessProvider(props: PropsWithChildren<Props>): JSX.Element {
   const { children, verticalKey, sessionTrackingEnabled=true, ...answersConfig } = props;
   const additionalHttpHeaders = {
     'Client-SDK': {

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -53,8 +53,7 @@ function useAnswersStateWithReactStoreSync<T>(stateSelector: StateSelector<T>): 
         }
         cb();
       }
-    })
-  , [answers]);
+    }), [answers]);
 
   const selectedState = useSyncExternalStoreWithSelector(
     subscribe,

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -7,8 +7,9 @@ export type StateSelector<T> = (s: State) => T;
 
 /**
  * Returns the Answers State returned by the map function.
- * used useSyncExternalStoreWithSelector to handle reading and subscribing from external store
- * in React version pre-18 and 18.
+ * Used useSyncExternalStoreWithSelector to handle reading
+ * and subscribing from external store in React version
+ * pre-18 and 18.
  */
 export function useAnswersState<T>(stateSelector: StateSelector<T>): T {
   const answers = useContext(AnswersHeadlessContext);

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -1,15 +1,76 @@
-import { useContext, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { State } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 
 export type StateSelector<T> = (s: State) => T;
+
+const canUseDOM = !!(typeof window !== 'undefined'
+  && typeof window.document !== 'undefined'
+  && typeof window.document.createElement !== 'undefined');
+const isServerEnvironment = !canUseDOM;
+
+/**
+ * use-sync-external-store/shim does not support getServerSnapshot for pre-18 React versions.
+ * It requires user of the shim to handle subscription logic and return the correct snapshot value.
+ * As such, server side rendering from pre-18 React version will use a version of useAnswersState that
+ * manually handle memoization of state selector and register subscription without useSyncExternalStore call.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useAnswersState = (React as any).useSyncExternalStore === undefined && isServerEnvironment
+  ? useAnswersStateWithManualStoreSync : useAnswersStateWithReactStoreSync;
+
+
+/**
+ * Returns the Answers State returned by the map function.
+ * UseSyncExternalStoreWithSelector is used to subscribe to external store and trigger rerender
+ * whenever an action is dispatched and caused changes to the state of the selector function.
+ */
+function useAnswersStateWithReactStoreSync<T>(stateSelector: StateSelector<T>): T {
+  const answers = useContext(AnswersHeadlessContext);
+  if (answers.state === undefined) {
+    throw new Error('Attempted to call useAnswersState() outside of AnswersHeadlessProvider.'
+     + ' Please ensure that \'useAnswersState()\' is called within an AnswersHeadlessProvider component.');
+  }
+
+  const getSnapshot = useCallback(() => answers.state, [answers.state]);
+  const isMountedRef = useRef<boolean>(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const subscribe = useCallback(cb =>
+    answers.addListener({
+      valueAccessor: state => state,
+      callback: () => {
+        // prevent React state update on an unmounted component
+        if (!isMountedRef.current) {
+          return;
+        }
+        cb();
+      }
+    })
+  , [answers]);
+
+  const selectedState = useSyncExternalStoreWithSelector(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+    stateSelector
+  );
+  return selectedState;
+}
+
 
 /**
  * Returns the Answers State returned by the map function.
  * Very similar to useSelector in react-redux.
  */
-export function useAnswersState<T>(stateSelector: StateSelector<T>): T {
+function useAnswersStateWithManualStoreSync<T>(stateSelector: StateSelector<T>): T {
   const answers = useContext(AnswersHeadlessContext);
   if (answers.state === undefined) {
     throw new Error('Attempted to call useAnswersState() outside of AnswersHeadlessProvider.'

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -7,8 +7,8 @@ export type StateSelector<T> = (s: State) => T;
 
 /**
  * Returns the Answers State returned by the map function.
- * UseSyncExternalStoreWithSelector is used to subscribe to external store and trigger rerender
- * whenever an action is dispatched and caused changes to the state of the selector function.
+ * used useSyncExternalStoreWithSelector to handle reading and subscribing from external store
+ * in React version pre-18 and 18.
  */
 export function useAnswersState<T>(stateSelector: StateSelector<T>): T {
   const answers = useContext(AnswersHeadlessContext);

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -7,7 +7,7 @@ export type StateSelector<T> = (s: State) => T;
 
 /**
  * Returns the Answers State returned by the map function.
- * Used useSyncExternalStoreWithSelector to handle reading
+ * Uses "use-sync-external-store/shim" to handle reading
  * and subscribing from external store in React version
  * pre-18 and 18.
  */

--- a/src/useAnswersState.tsx
+++ b/src/useAnswersState.tsx
@@ -1,33 +1,16 @@
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import { State } from '@yext/answers-headless';
 import { AnswersHeadlessContext } from './AnswersHeadlessContext';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 
 export type StateSelector<T> = (s: State) => T;
-
-const canUseDOM = !!(typeof window !== 'undefined'
-  && typeof window.document !== 'undefined'
-  && typeof window.document.createElement !== 'undefined');
-const isServerEnvironment = !canUseDOM;
-
-/**
- * use-sync-external-store/shim does not support getServerSnapshot for pre-18 React versions.
- * It requires user of the shim to handle subscription logic and return the correct snapshot value.
- * As such, server side rendering from pre-18 React version will use a version of useAnswersState that
- * manually handle memoization of state selector and register subscription without useSyncExternalStore call.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useAnswersState = (React as any).useSyncExternalStore === undefined && isServerEnvironment
-  ? useAnswersStateWithManualStoreSync : useAnswersStateWithReactStoreSync;
-
 
 /**
  * Returns the Answers State returned by the map function.
  * UseSyncExternalStoreWithSelector is used to subscribe to external store and trigger rerender
  * whenever an action is dispatched and caused changes to the state of the selector function.
  */
-function useAnswersStateWithReactStoreSync<T>(stateSelector: StateSelector<T>): T {
+export function useAnswersState<T>(stateSelector: StateSelector<T>): T {
   const answers = useContext(AnswersHeadlessContext);
   if (answers.state === undefined) {
     throw new Error('Attempted to call useAnswersState() outside of AnswersHeadlessProvider.'
@@ -55,78 +38,11 @@ function useAnswersStateWithReactStoreSync<T>(stateSelector: StateSelector<T>): 
       }
     }), [answers]);
 
-  const selectedState = useSyncExternalStoreWithSelector(
+  const selectedState = useSyncExternalStoreWithSelector<State, T>(
     subscribe,
     getSnapshot,
     getSnapshot,
     stateSelector
   );
   return selectedState;
-}
-
-
-/**
- * Returns the Answers State returned by the map function.
- * Very similar to useSelector in react-redux.
- */
-function useAnswersStateWithManualStoreSync<T>(stateSelector: StateSelector<T>): T {
-  const answers = useContext(AnswersHeadlessContext);
-  if (answers.state === undefined) {
-    throw new Error('Attempted to call useAnswersState() outside of AnswersHeadlessProvider.'
-     + ' Please ensure that \'useAnswersState()\' is called within an AnswersHeadlessProvider component.');
-  }
-
-  // useRef stores values across renders without triggering additional ones
-  const storedStoreState = useRef<State>(answers.state);
-  const storedSelector = useRef<StateSelector<T>>(stateSelector);
-  const storedSelectedState = useRef<T>();
-  /**
-   * Guard execution of {@link stateSelector} for initializing storedSelectedState.
-   * Otherwise it's run an additional time every render, even when storedSelectedState is already initialized.
-   */
-  if (storedSelectedState.current === undefined) {
-    storedSelectedState.current = stateSelector(answers.state);
-  }
-
-  /**
-   * The currently selected state - this is the value returned by the hook.
-   * Tries to use {@link storedSelectedState} when possible.
-   */
-  const selectedStateToReturn: T = (() => {
-    if (storedStoreState.current !== answers.state || storedSelector.current !== stateSelector) {
-      return stateSelector(answers.state);
-    }
-    return storedSelectedState.current;
-  })();
-
-  const [, triggerRender] = useState<T>(storedSelectedState.current);
-  useLayoutEffect(() => {
-    storedSelector.current = stateSelector;
-    storedStoreState.current = answers.state;
-    storedSelectedState.current = selectedStateToReturn;
-  });
-
-  useLayoutEffect(() => {
-    let unsubscribed = false;
-    const unsubscribe = answers.addListener({
-      valueAccessor: state => state,
-      callback: (state: State) => {
-        // prevent React state update on an unmounted component
-        if (unsubscribed) {
-          return;
-        }
-        const currentSelectedState = storedSelector.current(state);
-        if (storedSelectedState.current !== currentSelectedState) {
-          storedSelectedState.current = currentSelectedState;
-          triggerRender(currentSelectedState);
-        }
-      }
-    });
-    return () => {
-      unsubscribed = true;
-      unsubscribe();
-    };
-  }, [answers]);
-
-  return selectedStateToReturn;
 }

--- a/tests/useAnswersState.test.tsx
+++ b/tests/useAnswersState.test.tsx
@@ -69,7 +69,7 @@ it('does not perform extra renders/listener registrations for nested components'
   expect(childStateUpdates).toHaveLength(0);
 
   userEvent.click(screen.getByText('Search'));
-  await pendingVerticalQuery;
+  await act( async () => { await pendingVerticalQuery; });
 
   // Check that only a single addListener call is made for the conditionally rendered Child
   expect(addListenerSpy).toHaveBeenCalledTimes(2);
@@ -77,7 +77,7 @@ it('does not perform extra renders/listener registrations for nested components'
   expect(childStateUpdates).toHaveLength(1);
 
   userEvent.click(screen.getByText('Search'));
-  await pendingVerticalQuery;
+  await act( async () => { await pendingVerticalQuery; });
 
   // Check that additional addListener calls are not made
   expect(addListenerSpy).toHaveBeenCalledTimes(2);

--- a/tests/useAnswersState.test.tsx
+++ b/tests/useAnswersState.test.tsx
@@ -20,7 +20,6 @@ it('invoke useAnswersState outside of AnswersHeadlessProvider', () => {
 
 it('Retrieve state snapshot in server side rendering and hydration process', () => {
   const answers = createAnswersHeadless();
-  const consoleSpy = jest.spyOn(console, 'error');
   const mockedOnClick= jest.fn().mockImplementation(() => {
     answers.setVertical('anotherFakeKey');
   });
@@ -48,7 +47,6 @@ it('Retrieve state snapshot in server side rendering and hydration process', () 
   userEvent.click(screen.getByText('fakeVerticalKey'));
   expect(mockedOnClick).toBeCalledTimes(1);
   expect(screen.getByText('anotherFakeKey')).toBeDefined();
-  expect(consoleSpy).not.toBeCalled();
 });
 
 it('does not perform extra renders/listener registrations for nested components', async () => {

--- a/tests/useAnswersState.test.tsx
+++ b/tests/useAnswersState.test.tsx
@@ -18,7 +18,7 @@ it('invoke useAnswersState outside of AnswersHeadlessProvider', () => {
   jest.clearAllMocks();
 });
 
-it('Retrieve state snapshot in server side rendering and hydration process', () => {
+it('Retrieves state snapshot during server side rendering and hydration process', () => {
   const answers = createAnswersHeadless();
   const mockedOnClick= jest.fn().mockImplementation(() => {
     answers.setVertical('anotherFakeKey');


### PR DESCRIPTION
This pr updates answers-headless-react to support React 18 as well as 17.

- use alpha version 1.1.1.-alpha.0-95 of answers-headless which contains redux package update to support React 18.
- to support react 18 concurrent mode, useSyncExternalStore is needed. This pr uses `use-sync-external-store` package for backwards-compatible with pre-18 versions (v17).
  - ~~From [internal doc](https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreShimServer.js#L15)s in `use-sync-external-store`, the package does not offer much logic to support the case of server side rendering for react pre-18 versions. So, this pr update useAnswersState to be conditionally exported with either `useAnswersStateWithManualStoreSync` for SSR pre-18 or `useAnswersStateWithReactStoreSync` for everything else.~~ updated to use `use-sync-external-store` as is, without the manual handling, for all cases ([for more info](https://github.com/yext/answers-headless-react/pull/122#issuecomment-1136456564)).
  - with v17 version, there's warnings for state update on unmounted components, which we do get for when an async function (execute universal/vertical search) finish and send a series of dispatch that would trigger a re-render of a component that's already unmounted. There's no actual memory leak here since we always unsubscribe out listeners. This warning was removed in v18 (visit this [PR](https://github.com/facebook/react/pull/22114) for more details). As a workaround, `isMountedRef` is used in `useAnswersStateWithReactStoreSync` to track when a component is unmounted and prevent the callback for handlling store changes from triggering (cause component update).
  - update relevant packages to support v18 as well (`@testing-library/react`, `@types/react`)



Note: will release an alpha version of this for the component lib.

J=SLAP-2095
TEST=manual&auto
- added new jest tests for server side rendering and hydration process.
- see that jest tests passed successfully for V17 and V18. (note that @testing-library/react v13 drop support for 17 when beginning to support 18 in the same version)
- test (client side) with React version 17 and React version 18 in test-site from component lib repo.
  - with React verison 18. test with render (pre-18 syntax) and createRoot (18), ran a couple search and switch between universal and vertical page. see that both works as expected, although there is a warning for the former approach (`Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17.`) which is expected.
- test (SSR) with React version 17 and React version 18 with yext-site-starters repo. See that the assets were built successfully and the page function as expected.