### PR TITLE
add react 16.14 support to package.json + test different react versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,6 @@ jobs:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:
       build_script: |
-        npm i -D react@16 react-dom@16 @testing-library/react@12
+        npm i -D react@16.14 react-dom@16.14 @testing-library/react@12
         npm run build
       node_matrix: '["16.x"]'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,9 +12,12 @@ jobs:
       build_script: |
         npm i -D react@17 react-dom@17
         npm run build
+      node_matrix: '["16.x"]'
 
   call_run_tests:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      node_matrix: '["16.x"]'
 
   call_run_tests-react-16:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
@@ -22,3 +25,4 @@ jobs:
       build_script: |
         npm i -D react@16 react-dom@16
         npm run build
+      node_matrix: '["16.x"]'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:
       build_script: |
-        npm i -D react@17 react-dom@17
+        npm i -D react@17 react-dom@17 @testing-library/react@12
         npm run build
       node_matrix: '["16.x"]'
 
@@ -23,6 +23,6 @@ jobs:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:
       build_script: |
-        npm i -D react@16 react-dom@16
+        npm i -D react@16 react-dom@16 @testing-library/react@12
         npm run build
       node_matrix: '["16.x"]'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,5 +6,19 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
+  call_run_tests-react-17:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      build_script: |
+        npm i -D react@17 react-dom@17
+        npm run build
+
   call_run_tests:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+
+  call_run_tests-react-16:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      build_script: |
+        npm i -D react@16 react-dom@16
+        npm run build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 jobs:
   call_run_tests:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
-    with:
-      node_matrix: '["16.x"]'
 
   # It's necessary to use v12 of the react-testing-library since v13 was updated to only support react 18
   call_run_tests-react-17:
@@ -15,7 +13,6 @@ jobs:
       build_script: |
         npm i -D react@17 react-dom@17 @testing-library/react@12
         npm run build
-      node_matrix: '["16.x"]'
 
   call_run_tests-react-16:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
@@ -23,4 +20,3 @@ jobs:
       build_script: |
         npm i -D react@16.14 react-dom@16.14 @testing-library/react@12
         npm run build
-      node_matrix: '["16.x"]'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,22 +1,20 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Run Tests
 
 on: [push, pull_request]
 
 jobs:
+  call_run_tests:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      node_matrix: '["16.x"]'
+
+  # It's necessary to use v12 of the react-testing-library since v13 was updated to only support react 18
   call_run_tests-react-17:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:
       build_script: |
         npm i -D react@17 react-dom@17 @testing-library/react@12
         npm run build
-      node_matrix: '["16.x"]'
-
-  call_run_tests:
-    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
-    with:
       node_matrix: '["16.x"]'
 
   call_run_tests-react-16:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.123",
+  "version": "1.1.1-alpha.124",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless-react",
-      "version": "1.1.1-alpha.123",
+      "version": "1.1.1-alpha.124",
       "dependencies": {
         "@yext/answers-headless": "1.1.1-alpha.0-95",
         "use-sync-external-store": "^1.1.0"
@@ -46,7 +46,7 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "react": "^17 || ^18"
+        "react": "^16.14 || ^17 || ^18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless-react",
-  "version": "1.1.1-alpha.123",
+  "version": "1.1.1-alpha.124",
   "main": "./lib/esm/src/index.js",
   "types": "./lib/esm/src/index.d.ts",
   "exports": {
@@ -59,7 +59,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^17 || ^18"
+    "react": "^16.14 || ^17 || ^18"
   },
   "jest": {
     "bail": 0,


### PR DESCRIPTION
We support react 16.14 at latest - we do not support earlier versions of 16.
This is due to us using the newest jsx transform which was only added to 16.14 and not earlier versions of 16.
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

We could make answers-headless-react support earlier versions of react by changing our jsx transform
However in [yext/answers-react-components](https://github.com/yext/answers-react-components) we also depend on restart/ui which requires 16.14. Lastly, we already knew that redux-toolkit requires 16.9, which is another barrier
to support 16.8.

J=SLAP-2113
TEST=manual,auto

hook up local headless-react to local answers-react-components test site using react 16.14
see the components work as expected, and the dev tools say that the components are rendered by react-dom@16.14.0
try running vertical + universal searches, using numerical facets, using hierarchical facets