### PR TITLE
Add official release workflows

### DIFF
--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -1,0 +1,11 @@
+name: Create PR from main to develop
+
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  call_sync_develop_and_main:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/sync_develop_and_main.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -2,7 +2,7 @@ name: Create PR from main to develop
 
 on:
   push:
-    branches: [main, master]
+    branches: main
 
 jobs:
   call_sync_develop_and_main:

--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -1,0 +1,11 @@
+name: Update package version for release & hotfix branches
+
+on:
+  push:
+    branches: [release/*, hotfix/*]
+
+jobs:
+  call_version_update:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/version_update.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`version_update` and `sync_develop_and_main` workflows were added.

J=SLAP-2159
TEST=manual

Forked this repo, made a release branch and merged into main.  2 PRs were made: one updating for package version and one for merging main into develop.